### PR TITLE
Fix `lispy-kill-sentence` when on boundary of string

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1287,6 +1287,10 @@ Insert KEY if there's no command."
 (ert-deftest lispy-kill-sentence ()
   (should (string= (lispy-with "(progn|\n  (foo)\n  (bar))" (kbd "M-k"))
                    "(progn|)"))
+  (should (string= (lispy-with "(message |\"foo bar baz\")" (kbd "M-k"))
+                   "(message |)"))
+  (should (string= (lispy-with "(progn |(foo bar baz))" (kbd "M-k"))
+                   "(progn |)"))
   (should (string= (lispy-with "(message \"Then shalt thou count to three|, no more, no less.
 Three shall be the number thou shalt count, and the number of the
 counting shall be three.\")" (kbd "M-k"))

--- a/lispy.el
+++ b/lispy.el
@@ -832,7 +832,7 @@ Return nil if can't move."
 (defun lispy-kill-sentence ()
   "Kill until the end of current string or list."
   (interactive)
-  (if (looking-at lispy-left)
+  (if (or (looking-at lispy-left) (looking-at "\""))
       (lispy-delete 1)
     (let ((bnd
            (or (lispy--bounds-string)


### PR DESCRIPTION
This fixes an issue where <kbd>M-k</kbd> would leave a dangling double-quote in the buffer when issuing `lispy-kill-sentence` from the opening double-quote.  :point_up_2: 