### PR TITLE
Adjust `lispy-back' to always return to special positions

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -792,16 +792,26 @@ Return nil if can't move."
       (ring-insert lispy-pos-ring (point)))))
 
 (defun lispy-back (arg)
-  "Move point to ARGth previous position."
+  "Move point to ARGth previous position.  If position isn't
+special, move to previous or error."
   (interactive "p")
   (lispy-dotimes arg
     (if (zerop (ring-length lispy-pos-ring))
         (user-error "At beginning of point history")
       (let ((pt (ring-remove lispy-pos-ring 0)))
-        (if (consp pt)
-            (lispy--mark pt)
-          (deactivate-mark)
-          (goto-char pt))))))
+        (cond ((consp pt)
+               (lispy--mark pt))
+
+              ((save-excursion
+                 (goto-char pt)
+                 (or (looking-at lispy-left)
+                     (looking-back lispy-right)
+                     (looking-at lispy-outline)))
+               (deactivate-mark)
+               (goto-char pt))
+
+              (t
+               (lispy-back 1)))))))
 
 (defun lispy-knight-down ()
   "Make a knight-like move: down and right."


### PR DESCRIPTION
Curious about your opinion on this...

I use `lispy-back` all the time, but it falls over sometimes when you're rearranging things in your buffer, hit <kbd>bbbb</kbd> a few times and end up somewhere else inserting a bunch of `b` characters because the point you're returning to is no longer special because it was originally saved from a position that *was* special.

This amends `lispy-back` to skip over positions that aren't special.  There's still the possibility of you ending up in a place you never were, but at least you shouldn't end up inserting.

Is there a better way to handle this?