### PR TITLE
`lispy-ace-paren' should ignore paren under point

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1509,10 +1509,10 @@ Insert KEY if there's no command."
 
 (ert-deftest lispy-ace-paren ()
   (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
-                               (execute-kbd-macro (kbd "qb")))
+                               (execute-kbd-macro (kbd "qa")))
                    "(progn |(setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"))
   (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
-                               (execute-kbd-macro (kbd "qc")))
+                               (execute-kbd-macro (kbd "qb")))
                    "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"))
   (should (string= (lispy-with "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"
                                (execute-kbd-macro (kbd "qa")))

--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1508,15 +1508,26 @@ Insert KEY if there's no command."
                    "(cons 'n|orwegian 'blue)")))
 
 (ert-deftest lispy-ace-paren ()
-  (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
-                               (execute-kbd-macro (kbd "qa")))
-                   "(progn |(setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"))
-  (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
-                               (execute-kbd-macro (kbd "qb")))
-                   "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"))
-  (should (string= (lispy-with "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"
-                               (execute-kbd-macro (kbd "qa")))
-                   "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))")))
+  (let ((lispy-avy-ignore-current t))
+    (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qa")))
+                     "(progn |(setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"))
+    (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qb")))
+                     "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"))
+    (should (string= (lispy-with "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qa")))
+                     "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))")))
+  (let ((lispy-avy-ignore-current nil))
+    (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qb")))
+                     "(progn |(setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"))
+    (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qc")))
+                     "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"))
+    (should (string= (lispy-with "(progn (setq type 'norwegian-blue)\n       |(setq plumage-type 'lovely))"
+                                 (execute-kbd-macro (kbd "qa")))
+                     "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"))))
 
 (ert-deftest lispy-ace-symbol ()
   (should (string= (lispy-with "|(progn (setq type 'norwegian-blue)\n       (setq plumage-type 'lovely))"

--- a/lispy.el
+++ b/lispy.el
@@ -241,6 +241,11 @@ The hint will consist of the possible nouns that apply to the verb."
           (const :tag "At" at)
           (const :tag "Post" post)))
 
+(defcustom lispy-avy-ignore-current nil
+  "When t, `lispy' will not offer the current delimiter as a candidate."
+  :type 'boolean
+  :group 'lispy)
+
 (defcustom lispy-avy-keys (number-sequence ?a ?z)
   "Keys for jumping.")
 
@@ -3251,7 +3256,9 @@ When called twice in a row, restore point and mark."
        (lispy--bounds-dwim))
      (lambda ()
        (and (not (lispy--in-string-or-comment-p))
-            (not (equal (point) pt))))
+            (if lispy-avy-ignore-current
+                (not (equal (point) pt))
+              t)))
      lispy-avy-style-paren)))
 
 (defun lispy-ace-symbol (arg)

--- a/lispy.el
+++ b/lispy.el
@@ -3304,7 +3304,6 @@ Sexp is obtained by exiting list ARG times."
   "Visually select a match to REGEX within BND.
 Filter out the matches that don't match FILTER.
 Use STYLE function to update the overlays."
-  (require 'avy-jump)
   (lispy--recenter-bounds bnd)
   (let* ((avi-keys lispy-avy-keys)
          (cands (avi--regex-candidates

--- a/lispy.el
+++ b/lispy.el
@@ -3309,7 +3309,6 @@ Use STYLE function to update the overlays."
   (let* ((avi-keys lispy-avy-keys)
          (cands (avi--regex-candidates
                  regex
-                 (selected-window)
                  (car bnd) (cdr bnd)
                  filter)))
     (dolist (x cands)

--- a/lispy.el
+++ b/lispy.el
@@ -144,7 +144,7 @@
 (require 'outline)
 (require 'semantic)
 (require 'semantic/db)
-(require 'avy-jump)
+(require 'avy)
 (require 'newcomment)
 (require 'lispy-inline)
 (require 'iedit)

--- a/lispy.el
+++ b/lispy.el
@@ -3243,13 +3243,16 @@ When called twice in a row, restore point and mark."
   (interactive)
   (lispy--remember)
   (deactivate-mark)
-  (lispy--avy-do
-   lispy-left
-   (save-excursion
-     (lispy--out-backward 50)
-     (lispy--bounds-dwim))
-   (lambda () (not (lispy--in-string-or-comment-p)))
-   lispy-avy-style-paren))
+  (let ((pt (1+ (point))))
+    (lispy--avy-do
+     lispy-left
+     (save-excursion
+       (lispy--out-backward 50)
+       (lispy--bounds-dwim))
+     (lambda ()
+       (and (not (lispy--in-string-or-comment-p))
+            (not (equal (point) pt))))
+     lispy-avy-style-paren)))
 
 (defun lispy-ace-symbol (arg)
   "Jump to a symbol withing the current sexp and mark it.


### PR DESCRIPTION
This PR updates the predicate offered to `avi--regex-candidates` to filter out the paren at point.  It seems to make more sense to me to start the sequence at the next paren, since you don't want to jump to where you currently are. :)