### PR TITLE
Add more basic multiline cases for Clojure

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -2521,7 +2521,7 @@ When ARG is `fill', do nothing for short expressions."
 
 (setq-mode-local
  clojure-mode
- lispy--multiline-take-3 '(defn))
+ lispy--multiline-take-3 '())
 
 (defvar lispy--multiline-take-3-arg
   '(defun defmacro declare-function define-error defadvice defhydra defsubst)
@@ -2547,7 +2547,10 @@ The third one is assumed to be the arglist and will not be changed.")
 
 (setq-mode-local
  clojure-mode
- lispy--multiline-take-2 '(let fn def ns if))
+ lispy--multiline-take-2 '(loop recur let for fn def defn ns if -> ->>
+                           + +' - -' * *' / > >= < <= = ==
+                           or and not
+                           assoc! assoc assoc-in concat))
 
 (defvar lispy--multiline-take-2-arg '(declare lambda
                                       make-variable-buffer-local


### PR DESCRIPTION
Not comprehensive at all, just some cases I came across most often. `defn` should be take-2 not take-3 if you consider defn with multi-arity:
```
(defn foo
  ([x] (bar x))
  ([x y]
   (if (predicate? x)
     (bar x)
     (baz x))))
```
Further, for defn with docstrings take-2 is preferable.
```
;; good
(defn foo
  "docstring"
  [x]
  (bar x))

;; bad
(defn foo "docstring"
  [x]
  (bar x))
```