### PR TITLE
Add support for different kinds of clojure modes

### DIFF
--- a/Cask
+++ b/Cask
@@ -13,6 +13,7 @@
  (depends-on "slime")
  (depends-on "geiser")
  (depends-on "projectile")
+ (depends-on "clojure-mode")
  (depends-on "swiper")
  (depends-on "hydra")
  (depends-on "ace-window")

--- a/lispy-inline.el
+++ b/lispy-inline.el
@@ -94,6 +94,10 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
   '(emacs-lisp-mode lisp-interaction-mode eltex-mode minibuffer-inactive-mode)
   "Modes for which `lispy--eval-elisp' and related functions are appropriate.")
 
+(defvar lispy-clojure-modes
+  '(clojure-mode clojurescript-mode clojurex-mode)
+  "Modes for which clojure related functions are appropriate.")
+
 (defvar lispy-overlay nil
   "Hint overlay instance.")
 
@@ -127,7 +131,8 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
                (cond ((fboundp sym)
                       (setq lispy-hint-pos (point))
                       (lispy--show (lispy--pretty-args sym))))))
-            ((memq major-mode '(clojure-mode cider-repl-mode))
+            ((or (memq major-mode '(cider-repl-mode))
+                 (memq major-mode lispy-clojure-modes))
              (require 'le-clojure)
              (setq lispy-hint-pos (point))
              (lispy--show (lispy--clojure-args (lispy--current-function))))
@@ -191,7 +196,8 @@ Return t if at least one was deleted."
                               (describe-variable sym)
                               nil))
                            (t "unbound"))))
-                  ((memq major-mode '(clojure-mode cider-repl-mode))
+                  ((or (memq major-mode lispy-clojure-modes)
+                       (memq major-mode '(cider-repl-mode)))
                    (require 'le-clojure)
                    (let ((rsymbol (lispy--clojure-resolve sym)))
                      (string-trim-left

--- a/lispy.el
+++ b/lispy.el
@@ -1570,9 +1570,9 @@ When region is active, toggle a ~ at the start of the region."
 (defun lispy-hash ()
   "Insert #."
   (interactive)
-  (if (and (memq major-mode '(clojure-mode
-                              nrepl-repl-mode
-                              cider-clojure-interaction-mode))
+  (if (and (or (memq major-mode lispy-clojure-modes)
+               (memq major-mode '(nrepl-repl-mode
+                                  cider-clojure-interaction-mode)))
            (lispy-looking-back "\\sw #"))
       (progn
         (backward-delete-char 2)
@@ -3702,9 +3702,9 @@ Pass the ARG along."
   (cond ((memq major-mode lispy-elisp-modes)
          (lispy-flatten--elisp arg))
 
-        ((memq major-mode '(clojure-mode
-                            nrepl-repl-mode
-                            cider-clojure-interaction-mode))
+        ((or (memq major-mode lispy-clojure-modes)
+             (memq major-mode '(nrepl-repl-mode
+                                cider-clojure-interaction-mode)))
          (require 'le-clojure)
          (lispy-flatten--clojure arg))
 
@@ -4684,10 +4684,9 @@ When ADD-OUTPUT is t, append the output to the result."
   (funcall
    (cond ((memq major-mode lispy-elisp-modes)
           'lispy--eval-elisp)
-         ((memq major-mode '(clojure-mode
-                             clojurescript-mode
-                             nrepl-repl-mode
-                             cider-clojure-interaction-mode))
+         ((or (memq major-mode lispy-clojure-modes)
+              (memq major-mode '(nrepl-repl-mode
+                                 cider-clojure-interaction-mode)))
           (require 'le-clojure)
           (lambda (x)
             (lispy--eval-clojure x add-output t)))
@@ -5922,7 +5921,7 @@ The outer delimiters are stripped."
                    (goto-char (car bnd))
                    (current-column)))
          (was-left (lispy-left-p)))
-    (if (or (and (memq major-mode '(clojure-mode))
+    (if (or (and (memq major-mode lispy-clojure-modes)
                  (string-match "\\^" str))
             (> (length str) 10000))
 

--- a/lispy.el
+++ b/lispy.el
@@ -3208,7 +3208,7 @@ When ARG is 2, insert the result as a comment."
         "%" "%%" (lispy--eval (lispy--string-dwim) t))))))
 
 (defvar lispy-do-pprint nil
-  "Try a pretty-print when this ins't nil.")
+  "Try a pretty-print when this isn't nil.")
 
 (defun lispy-eval-and-insert (&optional arg)
   "Eval last sexp and insert the result.


### PR DESCRIPTION
There are
- clojure-mode
- clojurescript-mode
- clojurex-mode (for cljx, the old "cross compiler") that allows sharing
  code between clojure and clojurescript

These are different modes now in clojure-mode.el I guess, but they seem
to function the same way.

Also added support for different clojure modes in tests where it made
sense.