### PR TITLE
Remove evaluation result overlays after next command

### DIFF
--- a/lispy-inline.el
+++ b/lispy-inline.el
@@ -95,7 +95,7 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
   "Modes for which `lispy--eval-elisp' and related functions are appropriate.")
 
 (defvar lispy-clojure-modes
-  '(clojure-mode clojurescript-mode clojurex-mode)
+  '(clojure-mode clojurescript-mode clojurex-mode clojurec-mode)
   "Modes for which clojure related functions are appropriate.")
 
 (defvar lispy-overlay nil

--- a/lispy.el
+++ b/lispy.el
@@ -3215,8 +3215,7 @@ When ARG is 2, insert the result as a comment."
         (if (eq lispy-eval-display-style 'message)
             (message result)
           (if (fboundp 'cider--display-interactive-eval-result)
-              (let ((cider-eval-result-duration 1))
-                (cider--display-interactive-eval-result result (point)))
+              (cider--display-interactive-eval-result result (point))
             (error "Please install CIDER 0.10 to display overlay")))))))
 
 (defvar lispy-do-pprint nil


### PR DESCRIPTION
Cider originally had a bug in their overlay implementation, and lispy worked around that by always showing the evaluation results for one second. Now the bug has been fixed in cider, and we can show the overlay until the next command is entered - any command, such as movement, typing, etc.