### PR TITLE
Fix indentation for Clojure unquoting.

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1188,7 +1188,10 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "|(foo     \n bar)" (lispy--normalize-1))
                    "|(foo\n bar)"))
   (should (string= (lispy-with "|(require' foo)" (lispy--normalize-1))
-                   "|(require 'foo)")))
+                   "|(require 'foo)"))
+  (should (string= (lispy-with-clojure
+                    "|(expr ~(expr) ~'expr '~(expr) ~'(expr) ~@(expr))" (lispy--normalize-1))
+                   "|(expr ~(expr) ~'expr '~(expr) ~'(expr) ~@(expr))")))
 
 (ert-deftest lispy--sexp-normalize ()
   (should (equal

--- a/lispy.el
+++ b/lispy.el
@@ -6361,7 +6361,8 @@ The outer delimiters are stripped."
                    (current-column)))
          (was-left (lispy-left-p)))
     (if (or (and (memq major-mode lispy-clojure-modes)
-                 (string-match "\\^" str))
+                 (or (string-match "\\^" str)
+                     (string-match "~" str)))
             (> (length str) 10000))
 
         (lispy-from-left


### PR DESCRIPTION
This patch fixes spacing after indentation for Clojure unquoting and unquote-splicing.

After indentation:

```clojure
`(1 2 ~ (expr) ~ 'expr '~ (expr) ~ '(expr) ~@ (expr))
```

After indentation (applying patch):

```clojure
`(1 2 ~(expr) ~'expr '~(expr) ~'(expr) ~@(expr))
```

I'm just now familiarizing myself with lispy, so while the above patch seems to work, I'm not sure if there is a better place to fix the issue.