### PR TITLE
Fix documentation

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -51,7 +51,7 @@
 ;; `lispy' commands accept a numeric argument.  For instance, "3c" is
 ;; equivalent to "ccc" (clone sexp 3 times), and "4j" is equivalent to
 ;; "jjjj" (move point 4 sexps down).  Some useful applications are
-;; "9l" and "9a" - they exit list forwards and backwards respectively
+;; "9l" and "9h" - they exit list forwards and backwards respectively
 ;; at most 9 times which makes them effectively equivalent to
 ;; `end-of-defun' and `beginning-of-defun'.
 ;;


### PR DESCRIPTION
When swapping "a" and "h" in the default setup (ca6634fc), one example
in the commentary wasn't changed.