### PR TITLE
Check if fringe-mode is bound.

### DIFF
--- a/lispy-tags.el
+++ b/lispy-tags.el
@@ -63,7 +63,9 @@
                     (bound-and-true-p ivy-mode))))
       x
     (let* ((width (min (- (window-width)
-                          (if (eq fringe-mode 0) 1 0)) (cadr lispy-helm-columns)))
+                          (if (and (boundp 'fringe-mode)
+                                   (not (eq fringe-mode 0))) 0 1))
+                       (cadr lispy-helm-columns)))
            (s1 (car x))
            (s2 (file-name-nondirectory
                 (cadr x))))


### PR DESCRIPTION
If running in a terminal, fringe-mode is not available. Check if
fringe-mode is bound in lispy--format-tag-line to make it usable if
running in a terminal.