### PR TITLE
lispy.el (lispy-goto-symbol): No text properties.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -3366,7 +3366,7 @@ Sexp is obtained by exiting list ARG times."
 (defun lispy-goto-symbol (symbol)
   "Go to definition of SYMBOL.
 SYMBOL is a string."
-  (interactive (list (or (thing-at-point 'symbol)
+  (interactive (list (or (thing-at-point 'symbol t)
                          (lispy--current-function))))
   (let (rsymbol)
     (deactivate-mark)


### PR DESCRIPTION
Call thing-at-point with the optional no-properties argument, to strip
text properties. They cause trouble when calling slime-edit-definition.

Example:

    The value "mpd-single-p" is not of type CHARACTER.
       [Condition of type TYPE-ERROR]
    
    Restarts:
     0: [*ABORT] Return to SLIME's top level.
     1: [ABORT] abort thread (#<THREAD "worker" RUNNING {100516DA53}>)
    
    Backtrace:
      0: (SWANK::TOKENIZE-SYMBOL-THOROUGHLY #("mpd-single-p" 0 12 (SWANK-IO-PACKAGE::FONTIFIED T)))
      1: (SWANK::PARSE-SYMBOL #("mpd-single-p" 0 12 (SWANK-IO-PACKAGE::FONTIFIED T)) #<PACKAGE "MPD">)
      2: (SWANK::CALL-WITH-BUFFER-SYNTAX NIL #<CLOSURE (LAMBDA NIL :IN SWANK::FIND-DEFINITIONS-FIND-SYMBOL-OR-PACKAGE) {1005260F6B}>)
      3: ((FLET SWANK::DO-FIND :IN SWANK::FIND-DEFINITIONS-FIND-SYMBOL-OR-PACKAGE) #("mpd-single-p" 0 12 (SWANK-IO-PACKAGE::FONTIFIED T)))
      4: (SWANK::FIND-DEFINITIONS-FIND-SYMBOL-OR-PACKAGE #("mpd-single-p" 0 12 (SWANK-IO-PACKAGE::FONTIFIED T)))
 