### PR TITLE
Add tutorial navigation lesson

### DIFF
--- a/lispytutor/lispytutor.el
+++ b/lispytutor/lispytutor.el
@@ -23,15 +23,70 @@
 ;; bindings so don't be surprised if you find stuff inconvenient after
 ;; rebinding without thinking it through.
 ;;
-;; Your point should now be at beginning of line, use =C-a= if it isn't.
+;; Your point should now be at beginning of the first line.
+;; Press =M-<= if it isn't.
 ;;
-;; Press =j= to move to the next outline downwards.
+;; Press =J= to move to the next outline downwards.
 ;;
 ;; You should now be at Lesson 1.1.
 ;;
-;; Press =N= to narrow to the current outline.
+;; Press =i= to show the lesson.
+;; Press =N= to narrow to the lesson.
 ;;
-;;** Lesson 1.1: MOVING THE CURSOR
+;;** Lesson 1.1: TUTORIAL NAVIGATION
+;; This tutorial uses lispy outlines for navigation.
+;; 
+;; Outlines provide a way of navigating code in a tree-like fashion.
+;; The outlines themselves form the nodes of the tree.
+;; 
+;; An outline begins with a comment ";;" followed by or more asterisks.
+;; The number of asterisks determines the outline's depth in the tree.
+;; Your cursor should be at the start of the outline:
+;; ";;** Lesson 1.1: TUTORIAL NAVIGATION"
+;; 
+;; Place it there if it isn't already.
+;;
+;; Lispy enables special keybindings when your cursor is placed on an
+;; object lispy recognizes.
+;; 
+;; Here's a few to get started:
+;; =J= moves to the next outline
+;; =K= moves to the previous outline
+;; =i= cycles the expansion of the outline and its children.
+;;
+;; Press =J= and =K= a few times to navigate the outlines in this lesson.
+;; Try cycling the expansion of outlines with =i=.
+;; 
+;; When you're finished proceed to Exercise 1.
+;; 
+;;*** Exercise 1
+;; Lispy can "narrow" or "widen" outlines.
+;; 
+;; Narrowing an outline hides all the outlines in the buffer except
+;; for the outline at the cursor.  This is useful when you want to
+;; view or operate on the contents of a single outline.
+;;
+;; Press =N= to narrow to the outline for Exercise 1.
+;;
+;; Widening shows all outlines that have been hidden through
+;; narrowing.
+;;
+;; Press =W= to widen the outlines. Notice how the rest of the
+;; tutorial is displayed.
+;; 
+;; Move to Exercise 2, show it, and narrow to it using the
+;; shortcuts you've learned.
+;;
+;;*** Exercise 2
+;; Let's wrap up this lesson with one final shortcut.
+;; 
+;; =2-I= will show the condensed outline structure for all the visible
+;; outlines in the buffer.
+;; 
+;; Press =W= to show the hidden outlines.
+;; Press =2-I= and proceed to Lesson 1.2
+;; 
+;;** Lesson 1.2: MOVING THE CURSOR
 ;;
 ;; You can undo the narrow with `widen' command bound to =C-x nw=.  You
 ;; don't need to do this now, as this lesson is designed with narrowing in
@@ -103,7 +158,7 @@
 ;; and =k= have a guarantee not to leave the parent list.
 ;;
 ;; <--- To end the lesson, move the point here and press =W= (`widen').
-;;** Lesson 1.2: EXITING AND ENTERING SPECIAL
+;;** Lesson 1.3: EXITING AND ENTERING SPECIAL
 ;;
 ;; This is actually very straightforward: just press =C-f= or =C-n= or
 ;; =C-p= or anything else that makes the point not special.
@@ -125,7 +180,7 @@
 ;;   region. When the region is already active, try to extend it by
 ;;   one symbol.
 ;;
-;;** Lesson 1.3: LISP EDITING - DELETION
+;;** Lesson 1.4: LISP EDITING - DELETION
 ;;
 ;; To delete things, first you need to have a lot of them.
 ;;
@@ -165,7 +220,7 @@
                     ", and "))
   (princ ", and large chu...")
   (princ "\n\nSkip a bit, Brother..."))
-;;** Lesson 1.4: LISP EDITING - INSERTION
+;;** Lesson 1.5: LISP EDITING - INSERTION
 ;;
 ;; Basic insertion bindings:
 ;;
@@ -184,14 +239,14 @@
 ;; All four pairs will wrap the current thing when the region is active.
 ;; All four pairs will wrap the current symbol when prefixed with =C-u=.
 ;;
-;;** Lesson 1.5: LISP EDITING - APPENDING
+;;** Lesson 1.6: LISP EDITING - APPENDING
 ;;
 ;; You can append the current list:
 ;;
 ;; - from the front with =2 SPC=
 ;; - from the back with =3 SPC=
 ;; - from the back with a newline =4 SPC=
-;;** Lesson 1.6: OUTLINE NAVIGATION
+;;** Lesson 1.7: OUTLINE NAVIGATION
 ;;
 ;; Here, several bindings depend on conditions additional to being in
 ;; special.  Some of them are a superset of others, for example
@@ -225,4 +280,4 @@
 ;; even when not is special. It mirrors the popular `org-mode'
 ;; package, with the difference that it's a two-way toggle instead of
 ;; three-way. You can get the third option with a prefix argument.
-;;** Lesson 1.7: MOVING THE REGION
+;;** Lesson 1.8: MOVING THE REGION


### PR DESCRIPTION
I was thinking that we should tell the user to use <kbd>J</kbd> and <kbd>K</kbd> for navigating the outlines.  Later when list movement is covered, a note can be added that says <kbd>j</kbd> and <kbd>k</kbd> will navigate outlines as well.

How are you going to format the tutorial upon opening?  I was thinking it would be best to have all outlines collapsed except the root when the tutorial is opened.