### PR TITLE
Add lispy-wrap equivalents for brackets and braces

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -6544,6 +6544,16 @@ When ARG is non-nil, unquote the current string."
   (interactive)
   (lispy-parens 2))
 
+(defun lispy-wrap-brackets ()
+  "Forward to `lispy-brackets'"
+  (interactive)
+  (lispy-brackets 2))
+
+(defun lispy-wrap-braces ()
+  "Forward to `lispy-braces'"
+  (interactive)
+  (lispy-braces 2))
+
 (defun lispy-splice-sexp-killing-backward ()
   "Forward to `lispy-raise'."
   (interactive)


### PR DESCRIPTION
Please let me know if these commands are duplicated anywhere, but I added these commands because having keybinds like `M-{` for wrapping even outside of special (where I can do `2 {`) is nice.

Currently, one bug is that lispy-braces with arg 2 leaves point after closing brace, rather than after opening pair as with lispy-parens.