### PR TITLE
Add option for inserting space after wrapping

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -706,7 +706,10 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "|(a b c)\n(d e f)" (setq current-prefix-arg -1) "(")
                    "(| (a b c))\n(d e f)"))
   (should (string= (lispy-with "|(a b c)\n(d e f)" (setq current-prefix-arg 0) "(")
-                   "(| (a b c)\n (d e f))")))
+                   "(| (a b c)\n (d e f))"))
+  (let (lispy-insert-space-after-wrap)
+    (should (string= (lispy-with "a| b c" (kbd "C-u") "(")
+                     "(|a) b c"))))
 
 (ert-deftest lispy--sub-slurp-forward ()
   (should (eq (lispy-with-value "(progn\n  ~foo|-bar-baz-flip-flop)"

--- a/lispy.el
+++ b/lispy.el
@@ -314,6 +314,12 @@ non-nil."
   :group 'lispy
   :type 'number)
 
+(defcustom lispy-insert-space-after-wrap t
+  "When non-nil, insert a space after the point when wrapping.
+This applies to the commands that use `lispy-pair'."
+  :group 'lispy
+  :type 'boolean)
+
 ;;;###autoload
 (define-minor-mode lispy-mode
   "Minor mode for navigating and editing LISP dialects.
@@ -1525,13 +1531,12 @@ When this function is called:
             (insert ,left ,right)
             (save-excursion
               (lispy-slurp arg))
-            (cond ((looking-at lispy-right)
-                   (left-char)
-                   (just-one-space)
-                   (backward-char))
-                  ((not (eolp))
-                   (just-one-space)
-                   (backward-char)))))))
+            (when (looking-at lispy-right)
+              (backward-char))
+            (when (and lispy-insert-space-after-wrap
+                       (not (eolp)))
+              (just-one-space)
+              (backward-char))))))
 
 (defalias 'lispy-parens
     (lispy-pair "(" ")" "^\\|\\(?:> \\|#\\?\\)\\|\\s-\\|\\[\\|[{(`'#@~_%,]")


### PR DESCRIPTION
Do you think that t is the best default for this? I'm personally going to be setting it to nil and using the new `lispy-space` functionality when I want a space.

As for updating the documentation for `lispy-pair`, how should I generate the html from the org file?