### PR TITLE
Fix behavior of parinfer theme's delete command

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -2250,10 +2250,24 @@ Insert KEY if there's no command."
   (lispy-set-key-theme '(parinfer))
   (should (string= (lispy-with "(|a b c)" (kbd "DEL"))
                    "|a b c"))
+  (should (string= (lispy-with "(|(a b c))" (kbd "DEL"))
+                   "|(a b c)"))
   (should (string= (lispy-with "(a |b c)" (kbd "DEL") (kbd "DEL"))
                    "(|b c)"))
-  (should (string= (lispy-with "(a b)| c" (kbd "DEL"))
-                   "(a b| c)"))
+  (should (string= (lispy-with "((a b)| c)" (kbd "DEL"))
+                   "((a b| c))"))
+  (should (string= (lispy-with "(a)| (b)" (kbd "DEL"))
+                   "(a|) (b)"))
+  (should (string= (lispy-with "(((a)))|" (kbd "DEL") (kbd "DEL") (kbd "DEL"))
+                   "(((a|)))"))
+  (should (string= (lispy-with ";; (a (b)| c)"
+                               (setq current-prefix-arg 4)
+                               (kbd "DEL"))
+                   ";; (a| c)"))
+  (should (string= (lispy-with "\"(a (b)| c)\""
+                               (setq current-prefix-arg 4)
+                               (kbd "DEL"))
+                   "\"(a| c)\""))
   (lispy-set-key-theme '(special lispy c-digits oleh)))
 
 ;;* Paredit compatibility tests

--- a/lispy.el
+++ b/lispy.el
@@ -7557,15 +7557,26 @@ With an arg of -1, never wrap."
   (lispy-braces arg))
 
 (defun lispy-delete-backward-or-splice-or-slurp (arg)
-  "Call `lispy-delete-backward' unless after a delimiter
+  "Call `lispy-delete-backward' unless after a delimiter.
 After an opening delimiter, splice. After a closing delimiter, slurp to the end
-of the line without moving the point."
+of the line without moving the point unless at the top-level. When at the final
+delimiters of a top-level form or at the end of the line, move backward. In
+comments and strings, call `lispy-delete-backward'."
   (interactive "p")
-  (cond ((looking-back lispy-left)
-         (lispy-splice arg))
-        ((looking-back lispy-right)
+  (cond ((lispy--in-string-or-comment-p)
+         (lispy-delete-backward arg))
+        ((looking-back lispy-left)
          (save-excursion
-           (lispy-slurp -1)))
+           (backward-char)
+           (lispy-splice arg)))
+        ((looking-back lispy-right (1- (point)))
+         (if (= 0 (syntax-ppss-depth (syntax-ppss)))
+             (backward-char)
+           (let ((tick (buffer-chars-modified-tick)))
+             (save-excursion
+               (lispy-slurp -1))
+             (when (= tick (buffer-chars-modified-tick))
+               (backward-char arg)))))
         (t
          (lispy-delete-backward arg))))
 


### PR DESCRIPTION
This fixes the issues with `lispy-delete-backward-or-splice-or-slurp` brought up in #230. 