### PR TITLE
Improve lispy-pair on line with trailing spaces

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -789,6 +789,8 @@ Insert KEY if there's no command."
                    "(a\n (|))"))
   (should (string= (lispy-with "(a '|)" (setq current-prefix-arg -1) "(")
                    "(a '(|))"))
+  (should (string= (lispy-with "(a |) " (setq current-prefix-arg -1) "(")
+                   "(a (|)) "))
   (let (lispy-insert-space-after-wrap)
     (should (string= (lispy-with "a| b c" (kbd "C-u") "(")
                      "(|a) b c"))))

--- a/lispy.el
+++ b/lispy.el
@@ -5314,11 +5314,11 @@ whitespace."
   (let ((space "[[:space:]]")
         (special-syntax "[`'#@~_%,]"))
     (or (lispy--in-empty-list-p)
-        ;; top level
+        ;; empty line
         (and (looking-at (concat space "*$"))
              (lispy-looking-back (concat "^" space "*" special-syntax "*")))
         ;; empty position at end of list or line
-        (and (looking-at (concat space "*" lispy-right "*$"))
+        (and (looking-at (concat space "*" lispy-right "*" space "*$"))
              (lispy-looking-back (concat space "+" special-syntax "*")))
         ;; empty position at beginning of list
         (and (looking-at (concat "\\(" space "+\\|" space "*$\\)"))


### PR DESCRIPTION
This prevents trailing whitespace from changing the behavior of `lispy-pair`. Having trailing whitespace after a closing paren shouldn't really happen often, but it doesn't hurt to still have `lispy-pair` act correctly in this situation.