### PR TITLE
Fix problem with lispy-dedent-adjust-parens

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -301,7 +301,10 @@ Insert KEY if there's no command."
                    "(let ((a (1+))))\n|"))
   (should (string= (lispy-with "(((a)\n  |(b)\n  (c)\n  (d)))"
                                (lispy-dedent-adjust-parens 2))
-                   "(((a)))\n|(b)\n(c)\n(d)")))
+                   "(((a)))\n|(b)\n(c)\n(d)"))
+  (should (string= (lispy-with "(\n|a)"
+                               (lispy-dedent-adjust-parens 1))
+                   "()\n|a")))
 
 (ert-deftest lispy-move-left ()
   (should (string= (lispy-with "(progn\n |(sexp1)\n (sexp2))" "oh")

--- a/lispy.el
+++ b/lispy.el
@@ -2893,7 +2893,7 @@ the parentheses accordingly."
           ((region-active-p)
            (lispy-move-right arg))
           ((not line-type)
-           (lispy-mark-list 1)
+           (set-mark (point))
            (lispy-slurp 0)
            (lispy-move-right arg)
            (lispy-different)


### PR DESCRIPTION
This allows the dedent command to work properly even when the point is not at a list and fixes the `Unexpected` issue mentioned in #230.