### PR TITLE
Fix problems with lispy-indent-adjust-parens

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1806,9 +1806,16 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "(let ((a (1+))))\n|"
                                (lispy-indent-adjust-parens 1))
                    "(let ((a (1+)))\n  |)"))
-  ;; (should (string= (lispy-with "(progn\n  (foo))\n~(bar)\n(baz)|"
-  ;;                              (lispy-indent-adjust-parens 1))
-  ;;                  "(progn\n  (foo)\n  ~(bar)\n  (baz)|)"))
+  (should (string= (lispy-with "(progn\n  (foo))\n~(bar)\n(baz)|"
+                               (lispy-indent-adjust-parens 1))
+                   "(progn\n  (foo)\n  ~(bar)\n  (baz)|)"))
+  ;; multiple symbols on same line
+  (should (string= (lispy-with "(progn)\n|(foo) (bar)"
+                               (lispy-indent-adjust-parens 1))
+                   "(progn\n  |(foo) (bar))"))
+  (should (string= (lispy-with "(foo (bar))\n|baz bif"
+                               (lispy-indent-adjust-parens 1))
+                   "(foo (bar)\n     |baz bif)"))
   ;; test counts
   (should (string= (lispy-with "(let ((a (1+))))\n|"
                                (lispy-indent-adjust-parens 3))

--- a/lispy.el
+++ b/lispy.el
@@ -2262,11 +2262,23 @@ to the next level and adjusting the parentheses accordingly."
   "Indent the line if it is incorrectly indented or act as `lispy-up-slurp'.
 If the region is indented properly, call `lispy-up-slurp' ARG times."
   (interactive "p")
-  (let ((tick (buffer-chars-modified-tick)))
+  (let ((tick (buffer-chars-modified-tick))
+        (bnd (when (region-active-p)
+               (cons (region-beginning)
+                     (region-end)))))
     (indent-for-tab-command)
     (when (= tick (buffer-chars-modified-tick))
+      (if bnd
+          (lispy--mark bnd)
+        (unless (lispy--empty-line-p)
+          (set-mark (point))
+          (lispy-slurp -1)))
       (dotimes (_ arg)
-        (lispy-up-slurp)))))
+        (lispy-up-slurp))
+      (when (and (not bnd)
+                 (region-active-p))
+        (lispy-different)
+        (deactivate-mark)))))
 
 (defun lispy--backward-sexp-or-comment ()
   "When in comment, move to the comment start.


### PR DESCRIPTION
This fixes the test that was previously failing and makes the indent command work properly on a line with multiple sexps, as brought up in #230.