### PR TITLE
Improve lispy-slurp docstring

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -922,7 +922,12 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "a b |c~" (lispy-slurp -1))
                    "|a b c~"))
   (should (string= (lispy-with "a b |c~" (lispy-slurp 0))
-                   "|a b c~")))
+                   "|a b c~"))
+  ;; before a multi-line list
+  (should (string= (lispy-with "()| (a\n    b)" (lispy-slurp -1))
+                   "((a\n  b))|"))
+  (should (string= (lispy-with "~|(a\n b)" (lispy-slurp -1))
+                   "~(a\n b)|")))
 
 (ert-deftest lispy-barf ()
   (should (string= (lispy-with "((a) (b) (c))|" "<")
@@ -1816,6 +1821,9 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "(foo (bar))\n|baz bif"
                                (lispy-indent-adjust-parens 1))
                    "(foo (bar)\n     |baz bif)"))
+  ;; multi-line list
+  (should (string= (lispy-with "(a)\n|(b\n c)" (lispy-indent-adjust-parens 1))
+                   "(a\n |(b\n  c))"))
   ;; test counts
   (should (string= (lispy-with "(let ((a (1+))))\n|"
                                (lispy-indent-adjust-parens 3))

--- a/lispy.el
+++ b/lispy.el
@@ -2093,7 +2093,9 @@ Return the amount of successful grow steps, nil instead of zero."
 (defun lispy-slurp (arg)
   "Grow current sexp by ARG sexps.
 If ARG is zero, grow as far as possible. If ARG is -1, grow until the end or
-beginning of the line or as far as possible on the current line."
+beginning of the line. If it is not possible to slurp to the end of the line,
+slurp as far as possible within the line. If before a multi-line list, slurp to
+the end of the line where that list ends."
   (interactive "p")
   (if (region-active-p)
       (if (= (point) (region-end))


### PR DESCRIPTION
`(lispy-slurp -1)` will slurp past the current line when before a multi-line list instead of doing nothing. I was relying on this behavior for #240 and realized that this wasn't documented correctly.