### PR TITLE
Add support for SLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ and Clojure (via `cider`) are supported.  There's also basic
 evaluation support for:
 
 - Scheme (via `geiser`)
-- Common lisp (via `slime`).
+- Common lisp (via `slime` or `sly`).
 - Hy (via `comint`).
 - Python (via `comint` and `jedi`).
 - Julia (via `julia-shell`).

--- a/le-lisp.el
+++ b/le-lisp.el
@@ -23,25 +23,48 @@
 ;;; Code:
 
 (eval-and-compile
-  (ignore-errors (require 'slime)))
+  (ignore-errors (require 'slime))
+  (ignore-errors (require 'sly)))
 
 (declare-function slime-output-buffer "ext:slime-repl")
 (declare-function slime "ext:slime")
 (declare-function slime-current-connection "ext:slime")
 (declare-function slime-eval "ext:slime")
+(declare-function slime-edit-definition "ext:slime")
+(declare-function sly-mrepl--find-buffer "ext:sly-mrepl")
+(declare-function sly "ext:sly")
+(declare-function sly-current-connection "ext:sly")
+(declare-function sly-eval "ext:sly")
+(declare-function sly-edit-definition "ext:sly")
+
+(defcustom lispy-use-sly nil
+  "Whether to use SLY instead of SLIME."
+  :group 'lispy
+  :type 'boolean)
 
 (defun lispy--eval-lisp (str)
   "Eval STR as Common Lisp code."
-  (require 'slime-repl)
-  (unless (slime-current-connection)
+  (unless lispy-use-sly
+    (require 'slime-repl))
+  (unless (if lispy-use-sly
+              (sly-current-connection)
+            (slime-current-connection))
     (let ((wnd (current-window-configuration)))
-      (slime)
-      (while (not (and (slime-current-connection)
-                       (get-buffer-window (slime-output-buffer))))
+      (if lispy-use-sly
+          (sly)
+        (slime))
+      (while (not (if lispy-use-sly
+                      (when-let ((connection (sly-current-connection)))
+                        (sly-mrepl--find-buffer connection))
+                    (and
+                     (slime-current-connection)
+                     (get-buffer-window (slime-output-buffer)))))
         (sit-for 0.2))
       (set-window-configuration wnd)))
   (let* ((deactivate-mark nil)
-         (result (slime-eval `(swank:eval-and-grab-output ,str))))
+         (result (if lispy-use-sly
+                     (sly-eval `(slynk:eval-and-grab-output ,str))
+                   (slime-eval `(swank:eval-and-grab-output ,str)))))
     (if (equal (car result) "")
         (cadr result)
       (concat (propertize (substring (car result) 1)
@@ -56,7 +79,10 @@
           (mapconcat
            #'prin1-to-string
            (read (lispy--eval-lisp
-                  (format "(swank-backend:arglist #'%s)" symbol)))
+                  (format (if lispy-use-sly
+                              "(slynk-backend:arglist #'%s)"
+                            "(swank-backend:arglist #'%s)")
+                          symbol)))
            " "))))
     (if (listp args)
         (format
@@ -84,6 +110,10 @@
             \"undocumented\"))"
       symbol)))))
 
+(defun lispy-goto-symbol-lisp (symbol)
+  (if lispy-use-sly
+      (sly-edit-definition symbol)
+    (slime-edit-definition symbol)))
 
 (provide 'le-lisp)
 

--- a/lispy.el
+++ b/lispy.el
@@ -124,7 +124,7 @@
 ;;
 ;; Some Clojure support depends on `cider'.
 ;; Some Scheme support depends on `geiser'.
-;; Some Common Lisp support depends on `slime'.
+;; Some Common Lisp support depends on `slime' or `sly'.
 ;; You can get them from MELPA.
 ;;
 ;; See http://abo-abo.github.io/lispy/ for a detailed documentation.
@@ -1773,6 +1773,7 @@ When the region is active, toggle a ~ at the start of the region."
 
 (declare-function cider-repl-return "ext:cider-repl")
 (declare-function slime-repl-return "ext:slime-repl")
+(declare-function sly-mrepl-return "ext:sly-mrepl")
 (defun lispy-newline-and-indent-plain ()
   "When in minibuffer, exit it.  Otherwise forward to `newline-and-indent'."
   (interactive)
@@ -1783,6 +1784,8 @@ When the region is active, toggle a ~ at the start of the region."
      (cider-repl-return))
     (slime-repl-mode
      (slime-repl-return))
+    (sly-mrepl-mode
+     (sly-mrepl-return))
     (python-mode
      (newline-and-indent))
     (t
@@ -3659,7 +3662,7 @@ Sexp is obtained by exiting list ARG times."
 (defvar lispy-goto-symbol-alist
   '((clojure-mode lispy-goto-symbol-clojure le-clojure)
     (scheme-mode lispy-goto-symbol-scheme le-scheme)
-    (lisp-mode slime-edit-definition slime)
+    (lisp-mode lispy-goto-symbol-lisp le-lisp)
     (python-mode lispy-goto-symbol-python le-python))
   "An alist of `major-mode' to function for jumping to symbol.
 
@@ -5711,13 +5714,14 @@ so that no other packages disturb the match data."
      (in-package . 1)
      (load . 1)
      (setq . 2)
-     ;; SLIME specific
+     ;; SLIME/SLY specific
      (definterface . 1)
      (defimplementation . 1)
      (define-caller-pattern . 1)
      (define-variable-pattern . 1)
      (define-pattern-substitution . 1)
-     (defslimefun . 1))
+     (defslimefun . 1)
+     (defslyfun . 1))
     (emacs-lisp-mode
      (setq . 2)
      (csetq . 2)


### PR DESCRIPTION
This adds support for using [SLY](https://github.com/capitaomorte/sly) instead of SLIME. I've tested it with the eval functions, `C-1`, `C-2`, and `F`. `F` didn't previously start SLIME when it was't running. Should I change it so that it starts SLIME or SLY?

I don't `(require 'sly-mrepl)` in `lispy--eval-lisp` because it often errors for me (see capitaomorte/sly#79). The function from `sly-mrepl` will still work. Alternatively, I could put it in an `ignore-errors` if you want.