### PR TITLE
Ensure SLIME or SLY is running in lispy-goto-symbol-lisp

### DIFF
--- a/le-lisp.el
+++ b/le-lisp.el
@@ -133,6 +133,8 @@
         (lispy--insert body)))))
 
 (defun lispy-goto-symbol-lisp (symbol)
+  ;; start SLY or SLIME if necessary
+  (lispy--cl-process)
   (if lispy-use-sly
       (sly-edit-definition symbol)
     (slime-edit-definition symbol)))


### PR DESCRIPTION
This prevents the error in the case that SLY or SLIME hasn't yet been started.