### PR TITLE
Ignore cask, elc, backup, and lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /init.el
 /gh-pages/
 /.projectile
+/.cask/
+*.elc
+\#*#
+.#*
+*~


### PR DESCRIPTION
This is just a few additions to the `.gitignore` file.