### PR TITLE
Prevent unmatched right quotes from being deleted

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -651,6 +651,9 @@ Insert KEY if there's no command."
                        "~|"))
       (should (string= (lispy-with "a \"~(\"\"]\" \"((|)\" b" "\C-d")
                        "a \"~\"\"|)\" b"))
+      ;; test that a right quote at end of the region is not deleted
+      (should (string= (lispy-with "\"a ~string\"|" "\C-d")
+                       "\"a ~\"|"))
       ;; mixed
       (should (string= (lispy-with "~{[(a b \"(c|\" d)]}" "\C-d")
                        "~{[(\"|\" d)]}"))

--- a/lispy.el
+++ b/lispy.el
@@ -7411,7 +7411,7 @@ checked and nil will be returned."
                       (setq string-end (cdr string-bounds))))
                (setq matched-left-quote-p (= (1- (point))
                                              (car string-bounds)))
-               (cond ((< string-end end)
+               (cond ((< (1- string-end) end)
                       (goto-char string-end)
                       ;; when skipping strings, will only match right quote
                       ;; if left quote is not in the region


### PR DESCRIPTION
This fixes a bug for the safe actions where right quotes weren't considered unmatched if `lispy-safe-actions-ignore-strings` was non-nil and they were at the end of the region.
