### PR TITLE
Bump iedit to latest stable version v0.9.9.

### DIFF
--- a/lispy-pkg.el
+++ b/lispy-pkg.el
@@ -2,6 +2,6 @@
   "vi-like Paredit"
   '((emacs "24.1")
     (ace-window "0.9.0")
-    (iedit "0.97")
+    (iedit "0.9.9")
     (swiper "0.7.0")
     (hydra "0.13.4")))


### PR DESCRIPTION
I haven't tested this completely, but the tests do pass:

    Ran 133 tests, 133 results as expected (2016-04-26 11:05:20-0500)

I prefer to just use melpa-stable. The only version of iedit available in melpa-stable is 0.9.9. Based on the release histories, https://github.com/tsdh/iedit/releases and https://github.com/victorhge/iedit/releases, it would seem as though 0.97 is pretty out-of-date. I'm not certain 0.97 came from tsdh/iedit. It does seem like the new "official" repository is victorhge/iedit as that's what melpa points to: http://melpa.org/#/iedit.