### PR TITLE
Generalize deletion of delimiter-preceding syntax

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -601,6 +601,13 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "((a) |\"foo\" (c))"
                                (lispy-delete -1))
                    "(|\"foo\" (c))"))
+  ;; test that quotes also get deleted
+  (should (string= (lispy-with "'|()" "\C-d")
+                   "|"))
+  (should (string= (lispy-with "(,@|())" "\C-d")
+                   "(|)"))
+  (should (string= (lispy-with "#2A|((a b) (0 1))" "\C-d")
+                   "|"))
   (let ((lispy-safe-delete t))
     ;; region is already safe
     (should (string= (lispy-with "((a) ~(b (c (d)))|)" "\C-d")
@@ -1092,7 +1099,14 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "(asdf)\n(progn\n  |(foo)\n  (bar))\n(asdf)" "//")
                    "(asdf)\n|(progn\n  foo\n  bar)\n(asdf)"))
   (should (string= (lispy-with "(asdf)\n(progn\n  (foo)\n  (bar)|)\n(asdf)" "//")
-                   "(asdf)\n(progn\n  foo\n  bar)|\n(asdf)")))
+                   "(asdf)\n(progn\n  foo\n  bar)|\n(asdf)"))
+  ;; test that quotes also get deleted
+  (should (string= (lispy-with "'|(a)" "/")
+                   "|a"))
+  (should (string= (lispy-with "(,@|(a))" "/")
+                   "|(a)"))
+  (should (string= (lispy-with "#2A|((a b) (0 1))" "/")
+                   "|(a b) (0 1)")))
 
 (ert-deftest lispy-barf-to-point ()
   (should (string= (lispy-with "((a) (b)| (c))" (lispy-barf-to-point nil))
@@ -2392,6 +2406,13 @@ Insert KEY if there's no command."
   ;; space cleanup
   (should (string= (lispy-with "(foo (| (bar) baz))" (kbd "DEL"))
                    "(foo |(bar) baz)"))
+  ;; test that quotes also get deleted
+  (should (string= (lispy-with "'(|)" (kbd "DEL"))
+                   "|"))
+  (should (string= (lispy-with "(,@(|))" (kbd "DEL"))
+                   "(|)"))
+  (should (string= (lispy-with "#2A(|(a b) (0 1))" (kbd "DEL"))
+                   "|(a b) (0 1)"))
   (lispy-set-key-theme '(special lispy c-digits oleh)))
 
 (ert-deftest lispy-delete-or-splice-or-slurp ()
@@ -2424,6 +2445,13 @@ Insert KEY if there's no command."
                    "\"a b c\"|"))
   (should (string= (lispy-with "|\"a b c\"" (kbd "C-d"))
                    "|"))
+  ;; test that quotes also get deleted
+  (should (string= (lispy-with "'|()" (kbd "C-d"))
+                   "|"))
+  (should (string= (lispy-with "(,@|())" (kbd "C-d"))
+                   "(|)"))
+  (should (string= (lispy-with "#2A|((a b) (0 1))" (kbd "C-d"))
+                   "|(a b) (0 1)"))
   (lispy-set-key-theme '(special lispy c-digits oleh)))
 
 ;;* Paredit compatibility tests

--- a/lispy.el
+++ b/lispy.el
@@ -1144,7 +1144,7 @@ If position isn't special, move to previous or error."
            (lispy-left 1))
 
           ((lispy-left-p)
-           (lispy--delete-quote-garbage)
+           (lispy--delete-leading-garbage)
            (lispy-dotimes arg
              (lispy--delete)))
 
@@ -1162,20 +1162,15 @@ If position isn't special, move to previous or error."
           (t
            (delete-char arg)))))
 
-(defvar lispy-quote-regexp-alist
-  '((emacs-lisp-mode . "`',@")
-    (t . "`',@"))
-  "An alist of `major-mode' to a string.
-The regexp describes the possible quoting characters in front of
-the list.  When the list is deleted, these quotes, that are
-assumed to belong to the list are also deleted.")
-
-(defun lispy--delete-quote-garbage ()
-  "Delete any combination of `',@ preceeding point."
-  (let ((str (or (cdr (assoc major-mode lispy-quote-regexp-alist))
-                 (cdr (assoc t lispy-quote-regexp-alist))))
-        (pt (point)))
-    (skip-chars-backward str)
+(defun lispy--delete-leading-garbage ()
+  "Delete any syntax before an opening delimiter such as '.
+Delete backwards to the closest whitespace char or opening delimiter or to the
+beginning of the line."
+  (let ((pt (point)))
+    (re-search-backward (concat "[[:space:]]" "\\|"
+                                lispy-left "\\|"
+                                "^"))
+    (goto-char (match-end 0))
     (delete-region (point) pt)))
 
 (defun lispy--delete-whitespace-backward ()
@@ -2467,7 +2462,7 @@ When lispy-left, will slurp ARG sexps forwards.
              (save-excursion
                (goto-char (cdr bnd))
                (delete-char -1))
-             (lispy--delete-quote-garbage)
+             (lispy--delete-leading-garbage)
              (delete-char 1)
              (lispy-forward 1)
              (lispy-backward 1))
@@ -7809,7 +7804,7 @@ quote of a string, move backward."
            (save-excursion
              (lispy-different)
              (delete-char -1))
-           (lispy--delete-quote-garbage)
+           (lispy--delete-leading-garbage)
            (delete-char 1))
           ((looking-back lispy-right (1- (point)))
            (let ((tick (buffer-chars-modified-tick)))
@@ -7842,7 +7837,7 @@ quote of a string, move forward."
            (save-excursion
              (lispy-different)
              (delete-char -1))
-           (lispy--delete-quote-garbage)
+           (lispy--delete-leading-garbage)
            (delete-char 1))
           ((looking-at lispy-right)
            (let ((tick (buffer-chars-modified-tick)))


### PR DESCRIPTION
This implements the suggested behavior from #245 for some of the deletion/splicing commands by replacing `lispy--delete-quote-garbage` with a more generic `lispy--delete-leading-garbage`. 