### PR TITLE
Support lispy-goto-symbol in ClojureScript

### DIFF
--- a/le-clojure.el
+++ b/le-clojure.el
@@ -356,19 +356,7 @@ Besides functions, handles specials, keywords, maps, vectors and sets."
 
 (defun lispy-goto-symbol-clojure (symbol)
   "Goto SYMBOL."
-  (let ((rsymbol (lispy--clojure-resolve symbol)))
-    (cond ((stringp rsymbol)
-           (lispy--clojure-jump rsymbol))
-          ((eq rsymbol 'special)
-           (error "Can't jump to '%s because it's special" symbol))
-          ((eq rsymbol 'keyword)
-           (error "Can't jump to keywords"))
-          ((and (listp rsymbol)
-                (eq (car rsymbol) 'variable))
-           (error "Can't jump to Java variables"))
-          (t
-           (error "Could't resolve '%s" symbol))))
-  (lispy--back-to-paren))
+  (cider-find-var nil symbol))
 
 (provide 'le-clojure)
 

--- a/lispy.el
+++ b/lispy.el
@@ -3698,6 +3698,7 @@ Sexp is obtained by exiting list ARG times."
 
 (defvar lispy-goto-symbol-alist
   '((clojure-mode lispy-goto-symbol-clojure le-clojure)
+    (clojurescript-mode lispy-goto-symbol-clojure le-clojure)
     (scheme-mode lispy-goto-symbol-scheme le-scheme)
     (lisp-mode lispy-goto-symbol-lisp le-lisp)
     (python-mode lispy-goto-symbol-python le-python))


### PR DESCRIPTION
The current `lispy-goto-symbol-clojure` doesn't support ClojureScript, but `cider-find-var` does.

This change is a bit hack-and-slash; for one thing, we lose several nice error messages. I'm not sure this is the best way to implement this, but it's a start, and it works.