### PR TITLE
Include syntax before lists for lispy--bounds-dwim

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1909,7 +1909,9 @@ Insert KEY if there's no command."
   (should (string= (lispy-with "(progn ,@|(cdr re))" "mm")
                    "(progn ,@(cdr re)|)"))
   (should (string= (lispy-with-clojure "#|{:bar 'baz}" "0m")
-                   "#{~:bar 'baz|}")))
+                   "#{~:bar 'baz|}"))
+  (should (string= (lispy-with "#2A|((a b) (0 1))" "m")
+                   "~#2A((a b) (0 1))|")))
 
 (ert-deftest lispy-mark-car ()
   (should (string= (lispy-with "|\"foo\"~" "i")

--- a/lispy.el
+++ b/lispy.el
@@ -5473,9 +5473,13 @@ Otherwise return cons of current string, symbol or list bounds."
                 (when (setq bnd (lispy--bounds-comment))
                   (goto-char (1- (car bnd))))
                 (point)))))
-          ((or (looking-at (format "[`'#]*%s" lispy-left))
+          ((or (looking-at (concat "[^[:space:]]*" lispy-left))
                (looking-at "[`'#]"))
-           (bounds-of-thing-at-point 'sexp))
+           (setq bnd (bounds-of-thing-at-point 'sexp))
+           (save-excursion
+             (goto-char (car bnd))
+             (lispy--skip-delimiter-preceding-syntax-backward)
+             (cons (point) (cdr bnd))))
           ((looking-at ";;")
            (lispy--bounds-comment))
           ((and (eq major-mode 'python-mode)
@@ -5685,6 +5689,15 @@ Move to the end of line."
   (while (not (lispy--in-comment-p))
     (forward-line dir)
     (end-of-line)))
+
+(defun lispy--skip-delimiter-preceding-syntax-backward ()
+  "Move backwards past syntax that could precede an opening delimiter such as '.
+Specifically, move backwards to the closest whitespace char or opening delimiter
+or to the beginning of the line."
+  (re-search-backward (concat "[[:space:]]" "\\|"
+                              lispy-left "\\|"
+                              "^"))
+  (goto-char (match-end 0)))
 
 ;;* Utilities: evaluation
 (declare-function lispy--eval-clojure "le-clojure")


### PR DESCRIPTION
This addresses #245 by including any characters before an opening delimiter in the region returned by `lispy--bounds-dwim`. This fixes most of the commands that move sexps so that the preceding characters aren't left behind.