### PR TITLE
Improve lispy-indent-adjust-parens

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1820,6 +1820,12 @@ Insert KEY if there's no command."
                                (lispy-indent-adjust-parens 1)
                                (deactivate-mark))
                    "(a\n (b c)\n (d e)\n (|f g)"))
+  ;; just move point
+  (should (string= (lispy-with "((a)\n| )" (lispy-indent-adjust-parens 1))
+                   "((a)\n |)"))
+  ;; don't do anything; shouldn't error or move point
+  (should (string= (lispy-with "(a|)" (lispy-indent-adjust-parens 1))
+                   "(a|)"))
   ;; otherwise call lispy-up-slurp
   (should (string= (lispy-with "(let ((a (1+))))\n|"
                                (lispy-indent-adjust-parens 1))

--- a/lispy.el
+++ b/lispy.el
@@ -2315,14 +2315,18 @@ to the next level and adjusting the parentheses accordingly."
 
 (defun lispy-indent-adjust-parens (arg)
   "Indent the line if it is incorrectly indented or act as `lispy-up-slurp'.
-If the region is indented properly, call `lispy-up-slurp' ARG times."
+If indenting does not adjust indentation or move the point, call
+`lispy-up-slurp' ARG times."
   (interactive "p")
   (let ((tick (buffer-chars-modified-tick))
+        (pt (point))
         (bnd (when (region-active-p)
                (cons (region-beginning)
-                     (region-end)))))
+                     (region-end))))
+        up-slurp-success)
     (indent-for-tab-command)
-    (when (= tick (buffer-chars-modified-tick))
+    (when (and (= tick (buffer-chars-modified-tick))
+               (= pt (point)))
       (if bnd
           (lispy--mark bnd)
         (unless (lispy--empty-line-p)
@@ -2332,7 +2336,7 @@ If the region is indented properly, call `lispy-up-slurp' ARG times."
         (lispy-up-slurp))
       (when (and (not bnd)
                  (region-active-p))
-        (lispy-different)
+        (ignore-errors (lispy-different))
         (deactivate-mark)))))
 
 (defun lispy--backward-sexp-or-comment ()


### PR DESCRIPTION
This makes it so that `lispy-indent-adjust-parens` (like `lisp-indent-adjust-parens`) will also check if the point has moved when determining whether to slurp (related to #230).