### PR TITLE
Ensure we can call yank-pop after lispy-yank.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1081,6 +1081,7 @@ If position isn't special, move to previous or error."
 (defun lispy-yank ()
   "Like regular `yank', but quotes body when called from \"|\"."
   (interactive)
+  (setq this-command 'yank)
   (cond
     ((and (region-active-p)
           (bound-and-true-p delete-selection-mode))


### PR DESCRIPTION
`yank-pop` refuses to work unless it thinks the previous command was
`yank`, so set `this-command` appropriately.