### PR TITLE
Allow eldoc to work after lispy-space

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -8092,6 +8092,7 @@ FUNC is obtained from (`lispy--insert-or-call' DEF PLIST)."
     map))
 (eldoc-remove-command 'special-lispy-eval)
 (eldoc-remove-command 'special-lispy-x)
+(eldoc-add-command 'lispy-space)
 
 ;;* Parinfer compat
 (defun lispy--auto-wrap (func arg preceding-syntax-alist)


### PR DESCRIPTION
Since `lispy-space` isn't bound with `lispy-define-key`, `eldoc-add-command` is never called on it.