### PR TITLE
Tweak commenting at eolp

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -3618,7 +3618,8 @@ When SILENT is non-nil, don't issue messages."
                      (skip-chars-backward "\n\t ")
                      (forward-char 1)))))
               ((eolp)
-               (comment-dwim nil))
+               (comment-dwim nil)
+               (when lispy-comment-use-single-semicolon (just-one-space)))
               ((looking-at " *[])}]")
                (if lispy-comment-use-single-semicolon
                    (if (lispy-bolp)


### PR DESCRIPTION
Add just-one-space after `;`, so that consecutive calls to lispy-comment can
correctly cycle comment styles. I made this check for
`lispy-comment-use-single-semicolon`, but you could just as easily take out the
conditional, and tweak the `lispy-paredit-semicolon` test.