### PR TITLE
Minor fix to lispy--find-unmatched-delimiters

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -709,6 +709,9 @@ Insert KEY if there's no command."
                        "~{[(| d)]}"))
       (should (string= (lispy-with "{[(a~\n b\n ;; ]{](\n d)]}|" "\C-d")
                        "{[(a~)]}|"))
+      ;; delimiters before comments shouldn't be considered part of the comment
+      (should (string= (lispy-with "~(;; a\n |b)" "\C-d")
+                       "~(|b)"))
       ;; both mixed
       (should (string= (lispy-with "{[(a\n~   b \"c [(d e}\"\n   ;;({]\n|   f)]}"
                                    "\C-d")

--- a/lispy.el
+++ b/lispy.el
@@ -7873,7 +7873,7 @@ checked and nil will be returned."
             (cond
               ((and lispy-safe-actions-ignore-strings
                     (save-excursion
-                      (backward-char)
+                      (goto-char match-beginning)
                       (setq string-bounds (lispy--bounds-string))
                       (setq string-end (cdr string-bounds))))
                (setq matched-left-quote-p (= (1- (point))
@@ -7890,7 +7890,9 @@ checked and nil will be returned."
                         (push match-beginning left-positions))
                       (goto-char end))))
               ((and lispy-safe-actions-ignore-comments
-                    (setq comment-end (cdr (lispy--bounds-comment))))
+                    (save-excursion
+                      (goto-char match-beginning)
+                      (setq comment-end (cdr (lispy--bounds-comment)))))
                (if (< comment-end end)
                    (goto-char comment-end)
                  (goto-char end)))


### PR DESCRIPTION
This fixes an issue where safe deletion, for example, would delete an unmatched delimiter just before a comment (brought up in noctuid/lispyville#8).