### PR TITLE
Ignore empty regions in lispy-delete-backward

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1201,7 +1201,7 @@ Otherwise (`backward-delete-char-untabify' ARG)."
     (cond ((< arg 0)
            (lispy-delete (- arg)))
 
-          ((region-active-p)
+          ((use-region-p)
            (lispy--maybe-safe-delete-region (region-beginning)
                                             (region-end)))
           ((bobp))


### PR DESCRIPTION
Otherwise, pressing DEL (calling lispy-delete-backward) does nothing
when we have an active, empty region.

This is particularly common when using multiple-cursors. Previously,
DEL did nothing when multiple-cursors was active.