### PR TITLE
Make Lispy work with god-local-mode.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7800,7 +7800,8 @@ PLIST currently accepts:
                      lispy--cider-debug-command))))
 
              ,@(when (memq 'god-mode lispy-compat)
-                     '(((and (bound-and-true-p god-global-mode))
+                     '(((and (or (bound-and-true-p god-global-mode)
+                                 (bound-and-true-p god-local-mode)))
                         (call-interactively 'god-mode-self-insert))))
 
              ,@(when (memq 'macrostep lispy-compat)


### PR DESCRIPTION
God-mode comes in both a global and a local version. At the moment Lispy only works with god-global-mode. This is a trivial change to make it work with god-local-mode as well.