### PR TITLE
Add case to lispy-delete-backward to deal with accidental comments

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -801,11 +801,20 @@ Insert KEY if there's no command."
                    "(list |[1 2])"))
   (should (string= (lispy-with "#2A((a b) (0 1))|" "\C-?")
                    "|"))
+
   (let ((lispy-delete-atom-from-within t))
     (should (string= (lispy-with "(|)" "\C-?") "|"))
     (should (string= (lispy-with "(|foo)" "\C-?") "|"))
     (should (string= (lispy-with "\"|\"" "\C-?") "|"))
-    (should (string= (lispy-with "\"|foo\"" "\C-?") "|"))))
+    (should (string= (lispy-with "\"|foo\"" "\C-?") "|")))
+
+  (should (string= (lispy-with "(foo                                    ; |\n
+ )" "\C-?")
+                   "(foo|)"))
+  (should (string= (lispy-with ";; |" "\C-?")
+                   "|"))
+  (should (string= (lispy-with "(foo) ;; |" "\C-?")
+                   "(foo)|")))
 
 (ert-deftest lispy-pair ()
   (should (string= (lispy-with "\"\\\\|\"" "(")

--- a/lispy-test.el
+++ b/lispy-test.el
@@ -808,13 +808,11 @@ Insert KEY if there's no command."
     (should (string= (lispy-with "\"|\"" "\C-?") "|"))
     (should (string= (lispy-with "\"|foo\"" "\C-?") "|")))
 
-  (should (string= (lispy-with "(foo                                    ; |\n
- )" "\C-?")
+  (should (string= (lispy-with "(foo                                    ; |\n)" "\C-?")
                    "(foo|)"))
-  (should (string= (lispy-with ";; |" "\C-?")
-                   "|"))
-  (should (string= (lispy-with "(foo) ;; |" "\C-?")
-                   "(foo)|")))
+  (should (string= (lispy-with "(foo\n ;; |\n)" "\C-?") "(foo\n |\n)"))
+  (should (string= (lispy-with "(foo) ;; |" "\C-?") "(foo)|"))
+  (should (string= (lispy-with "(foo ;; |\n)" "\C-?") "(foo|)")))
 
 (ert-deftest lispy-pair ()
   (should (string= (lispy-with "\"\\\\|\"" "(")

--- a/lispy.el
+++ b/lispy.el
@@ -1242,12 +1242,18 @@ Otherwise (`backward-delete-char-untabify' ARG)."
              (delete-char -1)))
 
           ((lispy--in-comment-p)
-           (if (lispy-looking-back "^ +")
-               (progn
-                 (delete-region (1- (match-beginning 0))
-                                (match-end 0))
-                 (lispy--indent-for-tab))
-             (backward-delete-char-untabify arg)))
+           (cond ((lispy-looking-back "^ +")
+                  (delete-region (1- (match-beginning 0))
+                                 (match-end 0))
+                  (lispy--indent-for-tab))
+                 ((looking-at "$")
+                  (let ((pt (point)))
+                    (skip-chars-backward " ;")
+                    (delete-region (point) pt)
+                    (lispy--indent-for-tab)))
+
+                 (t
+                  (backward-delete-char-untabify arg))))
 
           ((lispy-looking-back "\\\\.")
            (backward-delete-char-untabify arg))

--- a/lispy.el
+++ b/lispy.el
@@ -1246,12 +1246,16 @@ Otherwise (`backward-delete-char-untabify' ARG)."
                   (delete-region (1- (match-beginning 0))
                                  (match-end 0))
                   (lispy--indent-for-tab))
-                 ((looking-at "$")
+                 ((and (looking-at "$") (looking-back "; +"))
                   (let ((pt (point)))
                     (skip-chars-backward " ;")
                     (delete-region (point) pt)
-                    (lispy--indent-for-tab)))
-
+                    (if (looking-back "^")
+                        (lispy--indent-for-tab)
+                      (let ((p (point)))
+                        (lispy--out-forward 1)
+                        (lispy--normalize-1)
+                        (goto-char p)))))
                  (t
                   (backward-delete-char-untabify arg))))
 


### PR DESCRIPTION
Addresses #329

One test is failing, I could use some help:

    (foo ;; |
    )

Leads to:

    (foo|
    )

I'd like to bring the closing paren up, but couldn't find a simple way to do it. I wish there was lispy--normalize-outer or something.