### PR TITLE
Consider map namespacing #::{} as valid in Clojure

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1622,11 +1622,11 @@ major mode. These regexps are used to determine whether to insert a space for
 `lispy-brackets'.")
 
 (defvar lispy-braces-preceding-syntax-alist
-  '((clojure-mode . ("[`'^]" "#[A-z.]*"))
-    (clojurescript-mode . ("[`'^]" "#[A-z.]*"))
-    (clojurec-mode . ("[`'^]" "#[A-z.]*"))
-    (cider-repl-mode . ("[`'^]" "#[A-z.]*"))
-    (cider-clojure-interaction-mode . ("[`'^]" "#[A-z.]*"))
+  '((clojure-mode . ("[`'^]" "#[:]*[A-z.:]*"))
+    (clojurescript-mode . ("[`'^]" "#[:]*[A-z.:]*"))
+    (clojurec-mode . ("[`'^]" "#[:]*[A-z.:]*"))
+    (cider-repl-mode . ("[`'^]" "#[:]*[A-z.:]*"))
+    (cider-clojure-interaction-mode . ("[`'^]" "#[:]*[A-z.:]*"))
     (t . nil))
   "An alist of `major-mode' to a list of regexps.
 Each regexp describes valid syntax that can precede an opening brace in that


### PR DESCRIPTION
Add `:` to the preceding syntax regexp for brackets in clojure. This will match the
following forms:

`#::{}`
`#:foo{}`

#356 