### PR TITLE
Always indent-sexp after lispy-tab

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7647,8 +7647,7 @@ The outer delimiters are stripped."
                     (or (string-match "\\^" str)
                         (string-match "~" str)))
                (> (length str) 10000))
-           (lispy-from-left
-            (indent-sexp)))
+           nil)
           ((looking-at ";;"))
           (t
            (let* ((max-lisp-eval-depth 10000)
@@ -7665,6 +7664,7 @@ The outer delimiters are stripped."
                (insert new-str)
                (when was-left
                  (backward-list))))))
+    (lispy-from-left (indent-sexp))
     (when (and (memq major-mode lispy-clojure-modes)
                clojure-align-forms-automatically)
       (clojure-align (car bnd) (cdr bnd)))))


### PR DESCRIPTION
Possibly fixes #367, unsure if best approach. Any thoughts