### PR TITLE
new lispy-colon-p to disable the insertion of a space before a colon

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1757,6 +1757,9 @@ If jammed between parens, \"(|(\" unjam: \"(| (\"."
                     (lispy-looking-back "[[({] "))
            (backward-char)))))
 
+(defvar lispy-colon-p t
+  "If true (the default), then add a space before inserting a colon following `lispy-colon-no-space-regex'. To disable this behavior, set this variable to nil.")
+
 (defvar lispy-colon-no-space-regex
   '((lisp-mode . "\\s-\\|[:^?#]\\|\\(?:\\s([[:word:]-]*\\)"))
   "Overrides REGEX that `lispy-colon' will consider for `major-mode'.
@@ -1766,9 +1769,10 @@ If jammed between parens, \"(|(\" unjam: \"(| (\"."
 (defun lispy-colon ()
   "Insert :."
   (interactive)
-  (lispy--space-unless
-   (or (cdr (assoc major-mode lispy-colon-no-space-regex))
-       "\\s-\\|\\s(\\|[#:^?]"))
+  (when lispy-colon-p
+    (lispy--space-unless
+     (or (cdr (assoc major-mode lispy-colon-no-space-regex))
+         "\\s-\\|\\s(\\|[#:^?]")))
   (insert ":"))
 
 (defun lispy-hat ()


### PR DESCRIPTION
Hello !

This would make the life of some of us easier :) In CL (at least) it is common practice to type a `lib:symbol` and thus the regexp (AFAIUnderstood) does not make much sense.

fixes #380 
