### PR TITLE
Cannot go to nil, and bounds dwim can produce nil if in front of a hash

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1605,7 +1605,8 @@ When this function is called:
            (t
             ;; don't jump backwards or out of a list when not at a sexp
             (unless (lispy--not-at-sexp-p ,preceding-syntax-alist)
-              (goto-char (car (lispy--bounds-dwim))))
+              (when (lispy--bounds-dwim)
+                (goto-char (car (lispy--bounds-dwim)))))
             (lispy--indent-for-tab)
             (insert ,left ,right)
             (save-excursion


### PR DESCRIPTION
- Use case is for typing a vector literal in Common Lisp
  such as `#(1 2 3)`