### PR TITLE
don't throw an error if cider isn't loaded before lispy

### DIFF
--- a/le-clojure.el
+++ b/le-clojure.el
@@ -93,6 +93,11 @@
   (remove-hook 'nrepl-connected-hook
                'lispy--clojure-eval-hook-lambda))
 
+;; if cider has not been loaded yet, define the var to avoid spurious error
+(if (not (boundp 'cider-jack-in-dependencies))
+    (defvar cider-jack-in-dependencies nil
+      "List of dependencies where elements are lists of artifact name and version."))
+
 (cider-add-to-alist 'cider-jack-in-dependencies
                     "org.tcrawley/dynapath" "0.2.5")
 (cider-add-to-alist 'cider-jack-in-dependencies


### PR DESCRIPTION
I am no elisp expert, forgive me if this is a terrible way to "fix" it, but I was confused by the fact that when `lispy` loads, it will complain if `cider` has not loaded yet (because the var `cider-jack-in-dependencies` is not defined yet). Perhaps it should use `with-eval-after-load` instead of the hack in this PR.

I autoload `clojure-mode`+`lispy` as soon as I open a buffer for a `.clj`, `.cljc`, `.edn` file, but not `cider`. I think `lispy` should load without `cider` and provide the features that don't require `cider`. (btw I use, and *love*, the `lispy` features that do require `cider` ... but sometimes I just want to open an `.edn` file and have emacs start AFAP).