### PR TITLE
Adding ability to disable region editing commands. This allows users of

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,10 @@ child of marked list, use <kbd>i</kbd> - `lispy-tab`.
 - <kbd>n</kbd> - `lispy-new-copy` - copy region as kill without deactivating the mark
 - <kbd>P</kbd> - `lispy-paste` - replace region with current kill
 
+## Disable region editing commands
+
+Set the variable `lispy-disable-region-commands` to `t` to disable the commands described in this section. This might be desired if you don't want to unlearn the behavior provided by `delete-selection-mode`. Note that this flag disables the bindings for many useful commands, but they are still available (e.g. via `M-x`).
+
 # IDE-like features
 
 These features are specific to the Lisp dialect used.  Currently Elisp

--- a/lispy.el
+++ b/lispy.el
@@ -201,6 +201,12 @@ The hint will consist of the possible nouns that apply to the verb."
   :type 'boolean
   :group 'lispy)
 
+(defcustom lispy-disable-region-commands nil
+  "If t, the region commands will be disabled, providing for directly inserting over a region via
+ delete-selection-mode."
+  :type 'boolean
+  :group 'lispy)
+
 (defcustom lispy-helm-columns '(70 80)
   "Max lengths of tag and tag+filename when completing with `helm'."
   :group 'lispy
@@ -8077,7 +8083,7 @@ PLIST currently accepts:
                          (setq lispy--compat-cmd (lookup-key magit-blame-mode-map (this-command-keys))))
                         (call-interactively lispy--compat-cmd))))
 
-             ((region-active-p)
+             ((and (not lispy-disable-region-commands) (region-active-p))
               (call-interactively ',def))
 
              ((lispy--in-string-or-comment-p)
@@ -8093,6 +8099,8 @@ PLIST currently accepts:
 
              (t
               (setq this-command 'self-insert-command)
+              (when lispy-disable-region-commands
+                (delete-selection-pre-hook))
               (call-interactively
                (quote
                 ,(or inserter


### PR DESCRIPTION
delete-selection-mode to preserve the usual behavior of inserting over an
active region to replace it.

The flag to disable the region editing commands is not active by default, so
there should be no change for existing lispy users.