### PR TITLE
lispy-eval-outline: replace % with %% in results

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -4195,7 +4195,7 @@ Return the result of the last evaluation as a string."
            (goto-char (car bnd))
            res)
           (t
-           (message res)))))
+           (message (replace-regexp-in-string "%" "%%" res))))))
 
 (defun lispy-message (str &optional popup)
   "Display STR in the echo area.


### PR DESCRIPTION
When results contain %, an error "not enough arguments for format string" would be issued. This should escape the % in result and fix the problem.