### PR TITLE
Support prefix arguments for lispy-wrap-round etc.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -8841,20 +8841,20 @@ When ARG is non-nil, unquote the current string."
      (backward-char 1))
     (t (lispy-delete-backward arg))))
 
-(defun lispy-wrap-round ()
-  "Forward to `lispy-parens'."
-  (interactive)
-  (lispy-parens 1))
+(defun lispy-wrap-round (arg)
+  "Forward to `lispy-parens' with a default ARG of 1."
+  (interactive "P")
+  (lispy-parens (or arg 1)))
 
-(defun lispy-wrap-brackets ()
-  "Forward to `lispy-brackets'"
-  (interactive)
-  (lispy-brackets 1))
+(defun lispy-wrap-brackets (arg)
+  "Forward to `lispy-brackets' with a default ARG of 1."
+  (interactive "P")
+  (lispy-brackets (or arg 1)))
 
-(defun lispy-wrap-braces ()
-  "Forward to `lispy-braces'"
-  (interactive)
-  (lispy-braces 1))
+(defun lispy-wrap-braces (arg)
+  "Forward to `lispy-braces' with a default ARG of 1."
+  (interactive "P")
+  (lispy-braces (or arg 1)))
 
 (defun lispy-splice-sexp-killing-backward ()
   "Forward to `lispy-raise'."


### PR DESCRIPTION
This just allows wrapping more than one sexp with `lispy-wrap-round`, `lispy-wrap-braces`, and `lispy-wrap-brackets`.

I noticed that `lispy-pair` will not actually wrap when in a string. This makes only makes sense for the autowrap commands. If the user explicitly gives an argument or uses `lispy-wrap-round`, I think it should always wrap. Would it be okay for me to change `lispy-pair` allow for this?

Also related, would it be okay for me to add a variable like this to allow `(` to insert `()` in strings?
```
(if (and lispy-parens-only-left-in-string ; defaults to t to preserve current behavior
         (string= ,left "(")
         (= ?\( (aref (this-command-keys-vector) 0)))
    (insert "(")
  (insert ,left ,right)
  (backward-char 1))
```