### PR TITLE
Delete space after opening delimiter with lispy-space

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -2234,6 +2234,8 @@ Insert KEY if there's no command."
 (ert-deftest lispy-space ()
   (should (string= (lispy-with "(|foo" " ")
                    "(| foo"))
+  (should (string= (lispy-with "(| foo)" " ")
+                   "(|foo)"))
   (should (string= (lispy-with "|(foo bar)" "2 ")
                    "(| foo bar)"))
   (should (string= (lispy-with "(foo bar)|" "2 ")

--- a/lispy.el
+++ b/lispy.el
@@ -1730,7 +1730,9 @@ otherwise the whole string is unquoted."
   "Insert one space, with position depending on ARG.
 If ARG is 2, amend the current list with a space from current side.
 If ARG is 3, switch to the different side beforehand.
-If jammed between parens, \"(|(\" unjam: \"(| (\"."
+If jammed between parens, \"(|(\" unjam: \"(| (\". If after an opening delimiter
+and before a space (after wrapping a sexp, for example), do the opposite and
+delete the extra space, \"(| foo)\" to \"(|foo)\"."
   (interactive "p")
   (cond ((bound-and-true-p edebug-active)
          (edebug-step-mode))
@@ -1758,8 +1760,13 @@ If jammed between parens, \"(|(\" unjam: \"(| (\"."
            (just-one-space)))
         ((and (lispy-looking-back lispy-left)
               (not (eq ?\\ (char-before (match-beginning 0)))))
-         (call-interactively 'self-insert-command)
-         (backward-char))
+         (if (looking-at "[[:space:]]")
+             (delete-region (point)
+                            (progn
+                              (skip-chars-forward "[:space:]")
+                              (point)))
+           (call-interactively 'self-insert-command)
+           (backward-char)))
         (t
          (call-interactively 'self-insert-command)
          (when (and (lispy-left-p)


### PR DESCRIPTION
I think it makes sense to be able to use `lispy-space` to toggle between `(| foo)` and `(|foo)`. In cases where the space is automatically inserted, this is more convenient than `C-d`, and as far as I know, there is no case where it makes sense to have multiple spaces after an opening delimiter.