### PR TITLE
Add variable listing modes lispy should not indent in

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7375,9 +7375,16 @@ Defaults to `error'."
       (forward-line 1))
     (move-marker end nil)))
 
+(defvar lispy-no-indent-modes '(minibuffer-inactive-mode
+                                comint-mode)
+  "List of major modes where `indent-for-tab-command' should not be used.
+`lispy--indent-for-tab' will do nothing if the current mode or any of its parent
+modes is in this list.")
+
 (defun lispy--indent-for-tab ()
   "Call `indent-for-tab-command'."
-  (unless (or (memq major-mode '(minibuffer-inactive-mode comint-mode))
+  (unless (or (memq major-mode lispy-no-indent-modes)
+              (apply #'derived-mode-p lispy-no-indent-modes)
               (= 0 (buffer-size)))
     (let ((tab-always-indent t))
       (lispy-flet (message (&rest _x))


### PR DESCRIPTION
Re #371. Sly and geiser have their own repl major modes that have `comint-mode` as a parent. ~~This adds `parent-mode` as a dependency, so that any mode that has `comint-mode` as a parent will automatically be covered. I can make it an optional dependency (only check parent modes if it can be loaded) or remove it entirely if you'd prefer.~~ Edit: Removed unecessary parent-mode dependency