### PR TITLE
Add lispy-stringify-oneline

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -3809,6 +3809,11 @@ Quote newlines if ARG isn't 1."
         (if (and leftp (= (point) (region-end)))
             (exchange-point-and-mark))))))
 
+(defun lispy-stringify-oneline ()
+  "Call `lispy-stringify' with a non-1 argument."
+  (interactive)
+  (lispy-stringify 0))
+
 (defun lispy-unstringify ()
   "Unquote string at point."
   (interactive)


### PR DESCRIPTION
I use this more than `lispy-stringify`, so I prefer to bind it directly instead.