### PR TITLE
Fix lispy-pair documentation

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1556,9 +1556,9 @@ When this function is called:
 - with arg nil:
   Insert LEFT RIGHT.
 - with arg negative:
-  Wrap as many sexps as possible with LEFT RIGHT.
-- with arg 0:
   Wrap as many sexps as possible until the end of the line with LEFT RIGHT.
+- with arg 0:
+  Wrap as many sexps as possible with LEFT RIGHT.
 - with the universal arg:
   Wrap one sexp with LEFT RIGHT.
 - with arg positive:


### PR DESCRIPTION
The documentation for a 0 arg and a negative arg was flipped.