### PR TITLE
Bug fix and clojure support for let splicing

### DIFF
--- a/lispy-test.el
+++ b/lispy-test.el
@@ -1177,8 +1177,15 @@ Insert KEY if there's no command."
                    "|(a)"))
   (should (string= (lispy-with "#2A|((a b) (0 1))" "/")
                    "|(a b) (0 1)"))
+  ;; let splicing
   (should (string= (lispy-with "(let (foo)\n  |(let ((bar (point)))\n    (baz)))" "/")
-                   "|(let (foo\n      (bar (point)))\n  (baz))")))
+                   "|(let (foo\n      (bar (point)))\n  (baz))"))
+  (should (string= (lispy-with "(let ((foo (point)))\n  |(let ((bar (1+ foo)))\n    (baz)))" "/")
+                   "|(let* ((foo (point))\n       (bar (1+ foo)))\n  (baz))"))
+  (should (string= (lispy-with "|(let (foo)\n  (let ((bar (point)))\n    (baz)))" "/")
+                   "let |(foo)\n  (let ((bar (point)))\n    (baz))"))
+  (should (string= (lispy-with-clojure "(let [foo 10]\n  |(let [bar 20]\n    (baz)))" "/")
+                   "|(let [foo 10\n      bar 20]\n  (baz))")))
 
 (ert-deftest lispy-barf-to-point ()
   (should (string= (lispy-with "((a) (b)| (c))" (lispy-barf-to-point nil))

--- a/lispy.el
+++ b/lispy.el
@@ -2673,37 +2673,56 @@ When lispy-left, will slurp ARG sexps forwards.
              (save-excursion
                (lispy-left 1)
                (looking-at "(let")))
-    (let ((child-binds (save-excursion
-                         (lispy-flow 2)
-                         (lispy--read (lispy--string-dwim))))
-          (parent-binds
-           (mapcar (lambda (x) (if (consp x) (car x) x))
-                   (save-excursion
-                     (lispy-up 1)
-                     (lispy--read (lispy--string-dwim)))))
-          (end (save-excursion
-                 (lispy-flow 2)
-                 (point)))
-          (beg (save-excursion
-                 (lispy-up 1)
-                 (lispy-different)
-                 (1- (point)))))
-      (save-excursion
-        (forward-list)
-        (delete-char -1))
-      (delete-region beg end)
-      (newline-and-indent)
-      (lispy-left 2)
-      (when (cl-find-if (lambda (v) (lispy-find v child-binds))
-                        parent-binds)
-        (if (looking-at "(\\(let\\)")
-            (progn
-              (replace-match "(let*")
-              (lispy--out-backward 1)
-              (indent-sexp))
-          (error "unexpected")))
-      (lispy--normalize-1))
+    (if (memq major-mode lispy-clojure-modes)
+        (lispy-splice-let-clojure)
+      (let ((child-binds (save-excursion
+                           (lispy-flow 2)
+                           (lispy--read (lispy--string-dwim))))
+            (parent-binds
+             (mapcar (lambda (x) (if (consp x) (car x) x))
+                     (save-excursion
+                       (lispy-up 1)
+                       (lispy--read (lispy--string-dwim)))))
+            (end (save-excursion
+                   (lispy-flow 2)
+                   (point)))
+            (beg (save-excursion
+                   (lispy-up 1)
+                   (lispy-different)
+                   (1- (point)))))
+        (save-excursion
+          (forward-list)
+          (delete-char -1))
+        (delete-region beg end)
+        (newline-and-indent)
+        (lispy-left 2)
+        (when (cl-find-if (lambda (v) (lispy-find v child-binds))
+                          parent-binds)
+          (if (looking-at "(\\(let\\)")
+              (progn
+                (replace-match "(let*")
+                (lispy--out-backward 1)
+                (indent-sexp))
+            (error "unexpected")))
+        (lispy--normalize-1)))
     t))
+
+(defun lispy-splice-let-clojure ()
+  "Join the current Clojure `let' form into the parent `let'."
+  (let ((end (save-excursion
+               (lispy-flow 1)
+               (1+ (point))))
+        (beg (save-excursion
+               (lispy-up 1)
+               (lispy-different)
+               (1- (point)))))
+    (save-excursion
+      (forward-list)
+      (delete-char -1))
+    (delete-region beg end)
+    (insert "\n")
+    (lispy--out-backward 2)
+    (lispy--normalize-1)))
 
 (defun lispy-barf-to-point (arg)
   "Barf to the closest sexp before the point.

--- a/lispy.el
+++ b/lispy.el
@@ -2669,9 +2669,9 @@ When lispy-left, will slurp ARG sexps forwards.
 
 (defun lispy-splice-let ()
   "Join the current `let' into the parent `let'."
-  (when (and (looking-at "(let")
-             (save-excursion
-               (lispy-left 1)
+  (when (save-excursion
+          (and (looking-at "(let")
+               (lispy--out-backward 1)
                (looking-at "(let")))
     (if (memq major-mode lispy-clojure-modes)
         (lispy-splice-let-clojure)


### PR DESCRIPTION
Currently attempting to splice a nested let form in Clojure produces confusing results, similarly for a top-level let form with no parent form.