### PR TITLE
Fix clojure bug when evaluating def with docstring

### DIFF
--- a/lispy-clojure-test.clj
+++ b/lispy-clojure-test.clj
@@ -20,6 +20,7 @@
 (ns lispy-clojure-test
   (:use [clojure.test :only [is deftest]]
         [lispy-clojure :only [add-location-to-defn
+                              add-location-to-def
                               debug-step-in
                               dest
                               expand-home
@@ -133,10 +134,14 @@
             x))))
 
 (deftest add-location-to-def-test
-  (let [e (lispy-clojure/add-location-to-def
-            '(def asdf 1) "/foo/bar.clj" 42)]
+  (let [e (add-location-to-def
+            '(def asdf 1) "/foo/bar.clj" 42)
+        e2 (add-location-to-def
+             '(def asdf "doc" 1) "/foo/bar.clj" 42)]
     (is (= e '(def asdf "" 1)))
+    (is (= e2 '(def asdf "doc" 1)))
     (is (= ((juxt :l-file :l-line) (meta (eval e)))
+           ((juxt :l-file :l-line) (meta (eval e2)))
            ["/foo/bar.clj" 42]))))
 
 (deftest guess-intent-test

--- a/lispy-clojure.clj
+++ b/lispy-clojure.clj
@@ -480,18 +480,17 @@ malleable to refactoring."
                 expr-map)
         ~@expr-tail))))
 
-(defn add-location-to-def [expr file line]
-  (let [name (nth expr 1)
-        [doc init] (if (and (string? (nth expr 2)) (> (count expr) 3))
-                     (rest expr)
-                     (cons "" (drop 2 expr)))]
-    (list 'def
-          (with-meta
-            name
-            {:l-file file
-             :l-line line})
-          doc
-          init)))
+(defn add-location-to-def
+  [[_def name & args] file line]
+  (apply list
+         _def
+         (with-meta
+           name
+           {:l-file file
+            :l-line line})
+         (if (> (count args) 1)
+           args
+           (cons "" args))))
 
 (defn add-location-to-deflike [expr file line]
   (when (and file line (list? expr))


### PR DESCRIPTION

Addresses one of the points in issue #478 - evaluating the following using `lispy-eval`
``` clojure
(def asdf "doc" 1)
```
causes a "too many arguments to def" error.
