### PR TITLE
Don't comment after `\` or `#`

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -3833,6 +3833,9 @@ When SILENT is non-nil, don't issue messages."
                       (insert " ;; "))
                      (t
                       (self-insert-command 1))))
+              ((or (eql (char-before) ?\\)
+                   (eql (char-before) ?\#))
+               (self-insert-command 1))
               ((lispy-left-p)
                (setq bnd (lispy--bounds-dwim))
                (when lispy-move-after-commenting


### PR DESCRIPTION
For example character constants `?\;` or scheme sexp comments `#;`