### PR TITLE
add some racket support

### DIFF
--- a/le-racket.el
+++ b/le-racket.el
@@ -1,0 +1,36 @@
+;;; le-racket.el --- lispy support for Racket. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2014-2015 Oleh Krehel
+
+;; This file is not part of GNU Emacs
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+(eval-and-compile
+  (require 'racket-mode nil t))
+
+(declare-function racket-lispy-visit-symbol-definition "racket-edit")
+
+
+(defun lispy-goto-symbol-racket (symbol)
+  (racket-lispy-visit-symbol-definition symbol))
+
+(provide 'le-racket)
+
+;;; le-racket.el ends here

--- a/lispy.el
+++ b/lispy.el
@@ -2037,6 +2037,8 @@ When the region is active, toggle a ~ at the start of the region."
       (inferior-emacs-lisp-mode
        (setq this-command 'ielm-return)
        (ielm-return))
+      (racket-repl-mode
+       (racket-repl-submit))
       (t
        (if (and (not (lispy--in-string-or-comment-p))
                 (if (memq major-mode lispy-clojure-modes)
@@ -4154,6 +4156,7 @@ Sexp is obtained by exiting list ARG times."
   '((clojure-mode lispy-goto-symbol-clojure le-clojure)
     (clojurescript-mode lispy-goto-symbol-clojurescript le-clojure)
     (scheme-mode lispy-goto-symbol-scheme le-scheme)
+    (racket-mode lispy-goto-symbol-racket le-racket)
     (lisp-mode lispy-goto-symbol-lisp le-lisp)
     (python-mode lispy-goto-symbol-python le-python))
   "An alist of `major-mode' to function for jumping to symbol.


### PR DESCRIPTION
- submitting input to racket REPL now works out-of-the-box
- go-to definition works

added some definitions to `racket-mode` too, see https://github.com/greghendershott/racket-mode/pull/374