### PR TITLE
Thread last

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Some pictures [here](#ide-like-features).
     - <kbd>i</kbd> prettifies code (remove extra space, hanging parens ...)
     - <kbd>xi</kbd> transforms `cond` expression to equivalent `if` expressions
     - <kbd>xc</kbd> transforms `if` expressions to an equivalent `cond` expression
+    - <kbd>x></kbd> transforms expressions from/to an equivalent `thread-last` expression
     - <kbd>xf</kbd> flattens function or macro call (extract body and substitute arguments)
     - <kbd>xr</kbd> evals and replaces
     - <kbd>xl</kbd> turns current `defun` into a `lambda`
@@ -385,6 +386,7 @@ A lot of Lispy commands come in pairs - one reverses the other:
  <kbd>S</kbd>   | `lispy-stringify`        | <kbd>C-u "</kbd>                 | `lispy-quotes`
  <kbd>;</kbd>   | `lispy-comment`          | <kbd>C-u ;</kbd>                 | `lispy-comment`
  <kbd>xi</kbd>  | `lispy-to-ifs`           | <kbd>xc</kbd>                    | `lispy-to-cond`
+ <kbd>x></kbd>  | `lispy-threaded-last`    | <kbd>x></kbd>                    | reverses itself
 
 ### Keys that modify whitespace
 

--- a/lispy-test.el
+++ b/lispy-test.el
@@ -138,6 +138,18 @@ Insert KEY if there's no command."
       (insert key))))
 
 ;;* Tests
+
+(ert-deftest lispy-toggle-threaded-last ()
+  (should (string= (lispy-with "|(thread-last (a) (b) (c))"
+                               (call-interactively #'lispy-threaded-last))
+                   "|(c (b (a)))"))
+  (should (string= (lispy-with "|(thread-last (a 1) (b 2) (c 3))"
+                               (call-interactively #'lispy-threaded-last))
+                   "|(c 3 (b 2 (a 1)))"))
+  (should (string= (lispy-with "|(c 3 (b 2 (a 1)))"
+                               (call-interactively #'lispy-threaded-last))
+                   "|(thread-last (a 1) (b 2) (c 3))")))
+
 (ert-deftest lispy-forward ()
   (should (string= (lispy-with "(|(a) (b) (c))" "]")
                    "((a)| (b) (c))"))

--- a/lispy.el
+++ b/lispy.el
@@ -533,6 +533,7 @@ Otherwise return the amount of times executed."
 
 (defmacro lispy-from-left (&rest body)
   "Ensure that BODY is executed from start of list."
+  (declare (debug (body)))
   (let ((at-start (cl-gensym "at-start")))
     `(let ((,at-start (lispy--leftp)))
        (unless ,at-start

--- a/lispy.el
+++ b/lispy.el
@@ -376,6 +376,10 @@ This applies to the commands that use `lispy-pair'."
   :group 'lispy
   :type 'boolean)
 
+(defcustom lispy-thread-last-macro 'thread-last
+  "Threading macro to use by default in command `lispy-to-threaded-last'."
+  :type 'symbol)
+
 (defun lispy-dir-string< (a b)
   (if (string-match "/$" a)
       (if (string-match "/$" b)
@@ -5330,6 +5334,44 @@ With ARG, use the contents of `lispy-store-region-and-buffer' instead."
   (lispy-from-left
    (indent-sexp)))
 
+(defun lispy-threaded-last ()
+  "Toggle current expression between last-threaded/unthreaded forms."
+  (interactive)
+  (lispy-from-left
+   (if (eq (car (read (current-buffer)))
+           lispy-thread-last-macro)
+       (call-interactively #'lispy-to-last-unthreaded)
+     (call-interactively #'lispy-to-threaded-last))))
+
+(defun lispy-to-threaded-last ()
+  "Transform current expression to equivalent threaded-last expression.
+Macro used may be customized in `lispy-thread-last-macro', which see."
+  (interactive)
+  (lispy-from-left
+   (let* ((bnd (lispy--bounds-dwim))
+          (expr (lispy--read (lispy--string-dwim bnd)))
+          (new-expr (lispy--thread-lastify expr lispy-thread-last-macro)))
+     (delete-region (car bnd) (cdr bnd))
+     (lispy--fast-insert
+      (lispy--whitespace-trim
+       new-expr))))
+  (lispy-from-left
+   (indent-sexp)))
+
+(defun lispy-to-last-unthreaded ()
+  "Transform current last-threaded expression to equivalent unthreaded expression."
+  (interactive)
+  (lispy-from-left
+   (let* ((bnd (lispy--bounds-dwim))
+          (expr (lispy--read (lispy--string-dwim bnd)))
+          (new-expr (lispy--unthread-lastify expr)))
+     (delete-region (car bnd) (cdr bnd))
+     (lispy--fast-insert
+      (lispy--whitespace-trim
+       new-expr))))
+  (lispy-from-left
+   (indent-sexp)))
+
 (defun lispy-unbind-variable ()
   "Substitute let-bound variable."
   (interactive)
@@ -5816,6 +5858,7 @@ An equivalent of `cl-destructuring-bind'."
   ("B" lispy-store-region-and-buffer "store list bounds")
   ("R" lispy-reverse "reverse")
   ("T" lispy-ert "ert")
+  (">" lispy-threaded-last "toggle last-threaded form")
   ("" lispy-x-more-verbosity :exit nil)
   ("?" lispy-x-more-verbosity "help" :exit nil))
 
@@ -7677,6 +7720,30 @@ Defaults to `error'."
          (cons
           (lispy--replace (car lst) from to)
           (lispy--replace (cdr lst) from to)))))
+
+(cl-defun lispy--thread-lastify (sexp &optional threading-macro)
+  "Return SEXP transformed into a threaded-last SEXP using THREADING-MACRO..
+THREADING-MACRO symbol should be, e.g. `thread-last' or `->>'."
+  (cl-labels ((rec (form)
+                   (if (and (consp form)
+                            (car (last form)))
+                       (if (consp (car (last form)))
+                           `(,@(rec (car (last form))) ,(butlast form))
+                         (list form))
+                     form)))
+    `(,threading-macro ,@(rec sexp))))
+
+(defun lispy--unthread-lastify (sexp)
+  "Return last-threaded SEXP unthreaded."
+  (cl-labels ((rec (form)
+                   (if (and (consp form)
+                            (car form))
+                       (if (and (consp (car form))
+                                (cadr form))
+                           `(,@(car (last form)) ,(rec (butlast form)))
+                         (car form))
+                     form)))
+    `(,@(rec (cdr sexp)))))
 
 ;;* Utilities: error reporting
 (defun lispy-complain (msg)


### PR DESCRIPTION
Hi Oleh,

This adds a new last-threading toggle command and associated functions.  This is something I do a lot, so having a command to quickly toggle between the forms is useful.  It seems to work well.  I added tests for some common forms, and documentation in what seem to be the right places.

Note that in a separate commit I also added a debug declaration to the `lispy-from-left` macro, which I used while debugging this new code.

Hopefully this will be acceptable, but please let me know if you would like any changes to be made.

Thanks for your work on this package.