### PR TITLE
Add minor support for janet lang

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1744,6 +1744,7 @@ When this function is called:
     (clojurec-mode . ("[`'~@]+" "#" "#\\?@?"))
     (cider-repl-mode . ("[`'~@]+" "#" "#\\?@?"))
     (cider-clojure-interaction-mode . ("[`'~@]+" "#" "#\\?@?"))
+    (janet-mode . ("[@;]"))
     (scheme-mode . ("[#`',@]+" "#hash"))
     (t . ("[`',@]+")))
   "An alist of `major-mode' to a list of regexps.
@@ -1757,6 +1758,7 @@ major mode. These regexps are used to determine whether to insert a space for
     (clojurec-mode . ("[`']" "#[A-z.]*"))
     (cider-repl-mode . ("[`']" "#[A-z.]*"))
     (cider-clojure-interaction-mode . ("[`']" "#[A-z.]*"))
+    (janet-mode . ("[@;]"))
     (scheme-mode . ("[#`',@]+" "#hash"))
     (t . nil))
   "An alist of `major-mode' to a list of regexps.
@@ -1770,6 +1772,7 @@ major mode. These regexps are used to determine whether to insert a space for
     (clojurec-mode . ("[`'^]" "#[:]*[A-z.:]*"))
     (cider-repl-mode . ("[`'^]" "#[:]*[A-z.:]*"))
     (cider-clojure-interaction-mode . ("[`'^]" "#[:]*[A-z.:]*"))
+    (janet-mode . ("[@;]"))
     (t . nil))
   "An alist of `major-mode' to a list of regexps.
 Each regexp describes valid syntax that can precede an opening brace in that

--- a/lispy.el
+++ b/lispy.el
@@ -383,6 +383,10 @@ This applies to the commands that use `lispy-pair'."
           (const :tag "Clojure" "->>")
           (string :tag "Custom")))
 
+(defun lispy-comment-char ()
+  "Get the comment-start character, or `;' if nil."
+  (or comment-start ";"))
+
 (defun lispy-dir-string< (a b)
   (if (string-match "/$" a)
       (if (string-match "/$" b)
@@ -830,7 +834,7 @@ Return nil if can't move."
         r)
     (cond
       ((and (lispy-bolp)
-            (looking-at ";"))
+            (looking-at (lispy-comment-char)))
        (setq r (lispy--re-search-in-code lispy-left 'forward arg)))
       ((lispy-left-p)
        (setq r (lispy--re-search-in-code lispy-left 'forward arg)))
@@ -895,7 +899,7 @@ Return nil if can't move."
              (goto-char pt))))
 
         ((or (looking-at lispy-outline)
-             (and (bolp) (looking-at ";")))
+             (and (bolp) (looking-at (lispy-comment-char))))
          (let ((pt (point)))
            (lispy-dotimes arg
              (outline-next-visible-heading 1)
@@ -963,7 +967,7 @@ Return nil if can't move."
              (lispy-different))))
 
         ((or (looking-at lispy-outline)
-             (and (bolp) (looking-at ";")))
+             (and (bolp) (looking-at (lispy-comment-char))))
          (let ((pt (point)))
            (lispy-dotimes arg
              (outline-previous-visible-heading 1)
@@ -1532,7 +1536,7 @@ When ARG is more than 1, mark ARGth element."
          (lispy--mark
           (lispy--bounds-dwim))
          (lispy-different))
-        ((and (lispy-bolp) (looking-at ";"))
+        ((and (lispy-bolp) (looking-at (lispy-comment-char)))
          (lispy--mark (lispy--bounds-comment))))
   (setq this-command 'lispy-mark-list))
 
@@ -3859,7 +3863,7 @@ When SILENT is non-nil, don't issue messages."
                       (forward-char 1))
                      ((lispy-after-string-p ";; ")
                       (backward-char 1)
-                      (insert ";")
+                      (insert (lispy-comment-char))
                       (forward-char 1))
                      ((and lispy-comment-use-single-semicolon
                            (lispy-after-string-p "; "))
@@ -3880,7 +3884,7 @@ When SILENT is non-nil, don't issue messages."
                (comment-region (car bnd) (cdr bnd))
                (when lispy-move-after-commenting
                  (when (or (lispy--in-string-or-comment-p)
-                           (looking-at ";"))
+                           (looking-at (lispy-comment-char)))
                    (lispy--out-backward 1))))
               ((lispy-right-p)
                (if lispy-comment-use-single-semicolon

--- a/lispy.el
+++ b/lispy.el
@@ -7289,6 +7289,7 @@ See https://clojure.org/guides/weird_characters#_character_literal.")
                 (match-string subexp)))
        nil t nil subexp))))
 
+;; TODO: Make the read test pass on string with semi-colon
 (defun lispy--read (str)
   "Read STR including comments and newlines."
   (let* ((deactivate-mark nil)
@@ -8253,6 +8254,8 @@ The outer delimiters are stripped."
 (defvar geiser-active-implementations)
 (defvar clojure-align-forms-automatically)
 (declare-function clojure-align "ext:clojure-mode")
+
+;; TODO: Make me work with janet...
 (defun lispy--normalize-1 ()
   "Normalize/prettify current sexp."
   (when (and (looking-at "(")
@@ -8288,9 +8291,11 @@ The outer delimiters are stripped."
                         (lispy--read str)))
                   (new-str (lispy--prin1-to-string res offset major-mode)))
              (unless (string= str new-str)
-               (delete-region (car bnd)
-                              (cdr bnd))
-               (insert new-str)
+               ;; We should not do this if new-str failed to eval.
+               (unless (string= "nil" new-str)
+                 (delete-region (car bnd)
+                                (cdr bnd))
+                 (insert new-str))
                (when was-left
                  (backward-list))))))
     (when (and (memq major-mode lispy-clojure-modes)


### PR DESCRIPTION
This handles a few major bugs / problems when trying to use lispy with Janet, and may make it more extensible in general.

I am just starting to look into the parsing logic to see how I can fix the problem where the parser encounters a `;` character in valid Janet source code, and does not seem to know how to continue reading the sexps that follow (I think it is interpreting it as either nil, or as a comment and then thinking the parens are unbalanced).

This PR does change the behavior when indent fails, from adding a literal 'nil' word into the user's buffer, to just not altering their indent sexp if it fails proper parsing.