### PR TITLE
Make lispy--undo-tree-advice have proper signature

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -8965,7 +8965,7 @@ Usage:
         (self-insert-command 1))
     (funcall orig-fun)))
 
-(defun lispy--undo-tree-advice (_arg)
+(defun lispy--undo-tree-advice (&optional _arg)
   "Advice to run before `undo-tree-undo'.
 
 Otherwise, executing undo in middle of a lispy overlay operation


### PR DESCRIPTION
undo-tree-undo takes an optional variable ARG, but lispy--undo-tree-advice
actually requires it. Make the argument optional.