### PR TITLE
lispy.el (lispy-alt-multiline): Fix bug

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -3837,7 +3837,8 @@ When SILENT is non-nil, don't issue messages."
          (expr (lispy--read str))
          (expr-o (lispy--oneline expr t))
          (expr-m (lispy--multiline-1 expr-o))
-         (leftp (lispy--leftp)))
+         (leftp (lispy--leftp))
+         (print-circle nil))
     (cond ((equal expr expr-m)
            (unless silent
              (message "No change")))


### PR DESCRIPTION
`lispy-alt-multiline` cannot be called when `print-circle` is t (traceback mentions
a bad transform).  Setting `print-circle` to nil in the command’s environment
fixes the problem.

Fixes #527.