### PR TITLE
Fix edebug-eval-expression when using lispy in minibuffer

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -8597,6 +8597,7 @@ Use only the part bounded by BND."
 (defun lispy--edebug-commandp ()
   "Return true if `this-command-keys' should be forwarded to edebug."
   (when (and (bound-and-true-p edebug-active)
+             (not (minibufferp))
              (= 1 (length (this-command-keys))))
     (let ((char (aref (this-command-keys) 0)))
       (setq lispy--edebug-command


### PR DESCRIPTION
Currently, with `(add-hook 'eval-expression-minibuffer-setup-hook #'lispy-mode)`, if you eval something while using edebug, pressing `e` again will call `edebug-eval-expression` again instead of self inserting.