### PR TITLE
Implement lispy-isolate

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1031,8 +1031,11 @@ If position isn't special, move to previous or error."
   (lispy-dotimes arg
     (if (zerop (ring-length lispy-pos-ring))
         (lispy-complain "At beginning of point history")
-      (pcase-let* ((`(,marker ,restriction) (ring-remove lispy-pos-ring 0))
-                   (`(,beg . ,end) restriction))
+      (let* ((data (ring-remove lispy-pos-ring 0))
+             (marker (pop data))
+             (restriction (pop data))
+             (beg (car restriction))
+             (end (cdr restriction)))
         ;; After deleting some text, markers that point to it converge
         ;; to one point
         (while (and (not (zerop (ring-length lispy-pos-ring)))

--- a/lispy.el
+++ b/lispy.el
@@ -1018,6 +1018,8 @@ Return nil if can't move."
   "Move point to ARGth previous position.
 If position isn't special, move to previous or error."
   (interactive "p")
+  (when (buffer-narrowed-p)
+    (widen))
   (lispy-dotimes arg
     (if (zerop (ring-length lispy-pos-ring))
         (lispy-complain "At beginning of point history")
@@ -4267,6 +4269,8 @@ SYMBOL is a string."
   (deactivate-mark)
   (with-no-warnings
     (ring-insert find-tag-marker-ring (point-marker)))
+  (when (buffer-narrowed-p)
+    (widen))
   (if (memq major-mode lispy-elisp-modes)
       (lispy-goto-symbol-elisp symbol)
     (let ((handler (cdr (assoc major-mode lispy-goto-symbol-alist)))

--- a/lispy.el
+++ b/lispy.el
@@ -1042,6 +1042,7 @@ If position isn't special, move to previous or error."
         (if (consp marker)
             (lispy--mark marker)
           (deactivate-mark)
+          (switch-to-buffer (marker-buffer marker))
           (goto-char marker))
         (when (and lispy-back-restore-restriction
                    restriction)

--- a/lispy.el
+++ b/lispy.el
@@ -4281,17 +4281,21 @@ SYMBOL is a string."
   (deactivate-mark)
   (with-no-warnings
     (ring-insert find-tag-marker-ring (point-marker)))
-  (when (buffer-narrowed-p)
-    (widen))
-  (if (memq major-mode lispy-elisp-modes)
-      (lispy-goto-symbol-elisp symbol)
-    (let ((handler (cdr (assoc major-mode lispy-goto-symbol-alist)))
-          lib)
-      (if (null handler)
-          (error "no handler for %S in `lispy-goto-symbol-alist'" major-mode)
-        (when (setq lib (cadr handler))
-          (require lib))
-        (funcall (car handler) symbol))))
+  (let ((narrowedp (buffer-narrowed-p)))
+    (when narrowedp
+      (widen))
+    (cond ((memq major-mode lispy-elisp-modes)
+           (lispy-goto-symbol-elisp symbol)
+           (when narrowedp
+             (lispy-narrow 1)))
+          (t
+           (let ((handler (cdr (assoc major-mode lispy-goto-symbol-alist)))
+                 lib)
+             (if (null handler)
+                 (error "no handler for %S in `lispy-goto-symbol-alist'" major-mode)
+               (when (setq lib (cadr handler))
+                 (require lib))
+               (funcall (car handler) symbol))))))
   ;; in case it's hidden in an outline
   (lispy--ensure-visible))
 

--- a/lispy.el
+++ b/lispy.el
@@ -1031,18 +1031,18 @@ If position isn't special, move to previous or error."
   (lispy-dotimes arg
     (if (zerop (ring-length lispy-pos-ring))
         (lispy-complain "At beginning of point history")
-      (pcase-let* ((`(,pt ,restriction) (ring-remove lispy-pos-ring 0))
+      (pcase-let* ((`(,marker ,restriction) (ring-remove lispy-pos-ring 0))
                    (`(,beg . ,end) restriction))
         ;; After deleting some text, markers that point to it converge
         ;; to one point
         (while (and (not (zerop (ring-length lispy-pos-ring)))
                     (equal (ring-ref lispy-pos-ring 0)
-                           pt))
+                           marker))
           (ring-remove lispy-pos-ring 0))
-        (if (consp pt)
-            (lispy--mark pt)
+        (if (consp marker)
+            (lispy--mark marker)
           (deactivate-mark)
-          (goto-char pt))
+          (goto-char marker))
         (when (and lispy-back-restore-restriction
                    restriction)
           (narrow-to-region beg end))))))

--- a/lispy.el
+++ b/lispy.el
@@ -1046,7 +1046,9 @@ If position isn't special, move to previous or error."
           (goto-char marker))
         (when (and lispy-back-restore-restriction
                    restriction)
-          (narrow-to-region beg end))))))
+          (narrow-to-region beg end)
+          (set-marker beg nil)
+          (set-marker end nil))))))
 
 (defun lispy-knight-down ()
   "Make a knight-like move: down and right."

--- a/lispy.el
+++ b/lispy.el
@@ -4263,6 +4263,7 @@ When LIB is non-nil, `require' it prior to calling FUNC.")
 SYMBOL is a string."
   (interactive (list (or (thing-at-point 'symbol t)
                          (lispy--current-function))))
+  (lispy--remember)
   (deactivate-mark)
   (with-no-warnings
     (ring-insert find-tag-marker-ring (point-marker)))


### PR DESCRIPTION
Hi there,

When I'm investigating a function, I like to narrow the buffer to it to make it easier to focus on it.  However, when I'm in an `edebug` session, I find it easier to clone the buffer, and narrow to that function in that cloned buffer.  It makes it easier to visit other functions in the file.

`lispy-isolate` is a proof-of-concept that does just that.  The name's not great, but before going forward, I'd prefer to make sure that you haven't already implemented something similar.  If not, I'd be willing to write something a little more fleshed out.