### PR TITLE
lispy-left docstring fix: it moves backwards not forwards.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -747,7 +747,7 @@ Self-insert otherwise."
     (lispy--out-forward arg)))
 
 (defun lispy-left (arg)
-  "Move outside list forwards ARG times.
+  "Move outside list backwards ARG times.
 Return nil on failure, t otherwise."
   (interactive "p")
   (lispy--remember)


### PR DESCRIPTION
I did not create a bug for this simple fix.  I figured that it'd be less work for you.  If you prefer to have bug reports even for those let me know.

(BTW: thanks for this great package!)