### PR TITLE
`lispy--space-unless': support comint

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7963,6 +7963,8 @@ Unless inside string or comment, or `looking-back' at CONTEXT."
                 (bolp)
                 (and (window-minibuffer-p)
                      (eq (point) (minibuffer-prompt-end)))
+                (and (derived-mode-p 'comint-mode)
+                     (= (point) (comint-line-beginning-position)))
                 (lispy--in-string-or-comment-p)
                 (lispy-looking-back context))
       (insert " "))))


### PR DESCRIPTION
`lispy--space-unless`: don't insert a space if at the start of a
`comint` prompt. This allows using `lispy-mode` in `sly-mrepl`.