### PR TITLE
Add lispy-show-top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ situation.
     - <kbd>F</kbd> jumps to symbol, <kbd>D</kbd> jumps back
     - <kbd>C-1</kbd> shows documentation in an overlay
     - <kbd>C-2</kbd> shows arguments in an overlay
+    - <kbd>C-5</kbd> shows first line of top-level form containing point
     - [<kbd>Z</kbd>](http://abo-abo.github.io/lispy/#lispy-edebug-stop) breaks
       out of `edebug`, while storing current function's arguments
 
@@ -533,6 +534,13 @@ As you see, normal, &optional and &rest arguments have each a
 different face. Here's how it looks for Clojure:
 
 ![screenshot](https://raw.github.com/abo-abo/lispy/master/images/arglist-clojure.png)
+
+**`lispy-show-top-level`**
+
+Bound to <kbd>C-5</kbd>. Show the first line of the top-level form
+containing the point. This is useful when the point is in a long
+top-level form for which the top has scrolled off the top of the
+window and is not visible.
 
 **`lispy-goto`**
 

--- a/lispy.el
+++ b/lispy.el
@@ -4854,6 +4854,15 @@ When ARG is non-nil, force select the window."
 
 (declare-function cider-doc-lookup "ext:cider-doc")
 
+(defun lispy-show-top-level ()
+  "Show first line of top-level form containing point."
+  (interactive)
+  (save-excursion
+    (lispy-right 1)
+    (lispy-beginning-of-defun)
+    (message "%s"
+             (buffer-substring (point-at-bol) (point-at-eol)))))
+
 (defun lispy-describe ()
   "Display documentation for `lispy--current-function'."
   (interactive)
@@ -5997,6 +6006,7 @@ An equivalent of `cl-destructuring-bind'."
   ;; ("q" nil)
   ("r" lispy-eval-and-replace "eval and replace")
   ("s" save-buffer)
+  ("S" lispy-show-top-level "show top-level form")
   ("t" lispy-view-test "view test")
   ("u" lispy-unbind-variable "unbind let-var")
   ("v" lispy-eval-expression "eval")
@@ -9698,6 +9708,7 @@ When ARG is non-nil, unquote the current string."
     (define-key map (kbd "C-2") 'lispy-arglist-inline)
     (define-key map (kbd "C-3") 'lispy-right)
     (define-key map (kbd "C-4") 'lispy-x)
+    (define-key map (kbd "C-5") 'lispy-show-top-level)
     (define-key map (kbd "C-7") 'lispy-cursor-down)
     (define-key map (kbd "C-8") 'lispy-parens-down)
     (define-key map (kbd "C-9") 'lispy-out-forward-newline)


### PR DESCRIPTION
Add a new command `lispy-show-top-level` which shows the first line of the top-level form containing the point in the echo area. This is useful for seeing which top-level form the point is in when the form is long enough that its beginning has scrolled off the top of the screen. The user might not always know which form they're in, e.g. if they jumped into the middle of a long form via a search or some other code navigation technique.

Bind to `C-5` outside special mode, and to `xS` inside special mode.  These are just suggested bindings, and can of course be changed if anyone has better ideas.