### PR TITLE
Improve cond<->if

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ A lot of Lispy commands come in pairs - one reverses the other:
  <kbd>O</kbd>   | `lispy-oneline`               | <kbd>M</kbd>                     | `lispy-multiline`
  <kbd>S</kbd>   | `lispy-stringify`             | <kbd>C-u "</kbd>                 | `lispy-quotes`
  <kbd>;</kbd>   | `lispy-comment`               | <kbd>C-u ;</kbd>                 | `lispy-comment`
- <kbd>xi</kbd>  | `lispy-to-ifs`                | <kbd>xc</kbd>                    | `lispy-to-cond`
+ <kbd>xc</kbd>  | `lispy-cond<->if-dwim`        | <kbd>xc</kbd>                    | reverses itself
  <kbd>x></kbd>  | `lispy-toggle-thread-last`    | <kbd>x></kbd>                    | reverses itself
 
 ### Keys that modify whitespace

--- a/lispy-test.el
+++ b/lispy-test.el
@@ -2017,7 +2017,9 @@ Insert KEY if there's no command."
 (ert-deftest lispy-to-ifs ()
   (should (or (version<= emacs-version "24.3.1") (string= (lispy-with "|(cond ((looking-at \" *;\"))\n      ((and (looking-at \"\\n\")\n            (looking-back \"^ *\"))\n       (delete-blank-lines))\n      ((looking-at \"\\\\([\\n ]+\\\\)[^\\n ;]\")\n       (delete-region (match-beginning 1)\n                      (match-end 1))))"
                                                                       (lispy-to-ifs))
-                                                          "|(if (looking-at \" *;\")\n    nil\n  (if (and (looking-at \"\\n\")\n           (looking-back \"^ *\"))\n      (delete-blank-lines)\n    (if (looking-at \"\\\\([\\n ]+\\\\)[^\\n ;]\")\n        (delete-region (match-beginning 1)\n                       (match-end 1)))))"))))
+                                                          "|(if (looking-at \" *;\")\n    nil\n  (if (and (looking-at \"\\n\")\n           (looking-back \"^ *\"))\n      (delete-blank-lines)\n    (if (looking-at \"\\\\([\\n ]+\\\\)[^\\n ;]\")\n        (delete-region (match-beginning 1)\n                       (match-end 1)))))")))
+  (should (string= (lispy-with "|(cond)" (lispy-to-ifs)) "|"))
+  (should (string= (lispy-with "|(cond [t 'q 'b])" (lispy-to-ifs)) "|(progn\n  'q 'b)")))
 
 (ert-deftest lispy-to-cond ()
   (should (or (version<= emacs-version "24.3.1")

--- a/lispy.el
+++ b/lispy.el
@@ -5460,6 +5460,17 @@ With ARG, use the contents of `lispy-store-region-and-buffer' instead."
   (lispy-from-left
    (indent-sexp)))
 
+(defun lispy-cond<->if-dwim ()
+  "Convert between `cond' and `if'."
+  (interactive)
+  (ignore-errors
+    (lispy-from-left
+     (let* ((bounds (lispy--bounds-dwim))
+            (expr (lispy--read (lispy--string-dwim bounds))))
+       (if (eq (car expr) 'if)
+           (lispy-to-cond)
+         (lispy-to-ifs))))))
+
 (defun lispy-toggle-thread-last ()
   "Toggle current expression between last-threaded/unthreaded forms.
 Macro used may be customized in `lispy-thread-last-macro', which see."
@@ -5977,7 +5988,7 @@ An equivalent of `cl-destructuring-bind'."
   "x"
   ;; ("a" nil)
   ("b" lispy-bind-variable "bind variable")
-  ("c" lispy-to-cond "to cond")
+  ("c" lispy-cond<->if-dwim "to cond")
   ("C" lispy-cleanup "cleanup")
   ("d" lispy-to-defun "to defun")
   ("D" lispy-extract-defun "extract defun")
@@ -5986,7 +5997,6 @@ An equivalent of `cl-destructuring-bind'."
   ("F" lispy-let-flatten "let-flatten")
   ;; ("g" nil)
   ("h" lispy-describe "describe")
-  ("i" lispy-to-ifs "to ifs")
   ("j" lispy-debug-step-in "debug step in")
   ("k" lispy-extract-block "extract block")
   ("l" lispy-to-lambda "to lambda")

--- a/lispy.el
+++ b/lispy.el
@@ -7804,7 +7804,8 @@ Defaults to `error'."
 (defun lispy--cases->ifs (cases)
   "Return nested if statements that correspond to CASES."
   (cond ((= 1 (length cases))
-         (if (memq (caar cases) '(t :else))
+         (if (or (memq (caar cases) '(t :else))
+                 (and (derived-mode-p 'scheme-mode) (eq (caar cases) 'else)))
              (let ((then (cdar cases)))
                (if (equal (car then) '(ly-raw newline))
                    (cdr then)

--- a/lispy.el
+++ b/lispy.el
@@ -7793,7 +7793,8 @@ The result is always a list."
 
 (defun lispy--cases->ifs (cases)
   "Return nested if statements that correspond to CASES."
-  (cond ((= 1 (length cases))
+  (cond ((null cases) nil)
+        ((= 1 (length cases))
          (if (let ((sym (lispy--first (car cases))))
                (or (memq sym '(t :else))
                    (and (derived-mode-p 'scheme-mode) (eq sym 'else))))

--- a/lispy.el
+++ b/lispy.el
@@ -5427,6 +5427,12 @@ With ARG, use the contents of `lispy-store-region-and-buffer' instead."
       (when begp
         (goto-char (car bnd))))))
 
+(defun lispy--progn (exprs)
+  "Like `macroexp-progn', but for `lispy--fast-insert'."
+  (if (cdr exprs)
+      `(progn (ly-raw newline) ,@exprs)
+    (car exprs)))
+
 (defun lispy-cond<->if-dwim ()
   "Convert between `cond' and `if'.
 If before an `if' or `case' (`cl-case'), transform to `cond'. If
@@ -5443,7 +5449,7 @@ before a `cond', transform to if."
                         (cons 'cond (lispy--ifs->cases expr)))
                        ((eq (car expr) 'cond)
                         (when-let ((cases (lispy--cases->ifs (cdr expr))))
-                          (car (lispy--whitespace-trim cases))))
+                          (lispy--progn (lispy--whitespace-trim cases))))
                        ((memq (car expr) '(case cl-case))
                         (lispy--case->cond expr))
                        (t

--- a/lispy.el
+++ b/lispy.el
@@ -5442,15 +5442,16 @@ before a `cond', transform to if."
             (res (cond ((eq (car expr) 'if)
                         (cons 'cond (lispy--ifs->cases expr)))
                        ((eq (car expr) 'cond)
-                        (car
-                         (lispy--whitespace-trim
-                          (lispy--cases->ifs (cdr expr)))))
+                        (and (cdr expr)
+                             (car
+                              (lispy--whitespace-trim
+                               (lispy--cases->ifs (cdr expr))))))
                        ((memq (car expr) '(case cl-case))
                         (lispy--case->cond expr))
                        (t
                         (error "Can't convert %s" (car expr))))))
        (delete-region (car bnd) (cdr bnd))
-       (lispy--fast-insert res)))
+       (when res (lispy--fast-insert res))))
     (lispy-from-left
      (indent-sexp))))
 (defalias 'lispy-to-cond #'lispy-cond<->if-dwim)

--- a/lispy.el
+++ b/lispy.el
@@ -7804,7 +7804,7 @@ Defaults to `error'."
 (defun lispy--cases->ifs (cases)
   "Return nested if statements that correspond to CASES."
   (cond ((= 1 (length cases))
-         (if (eq (caar cases) t)
+         (if (memq (caar cases) '(t :else))
              (let ((then (cdar cases)))
                (if (equal (car then) '(ly-raw newline))
                    (cdr then)


### PR DESCRIPTION
- Unify `lispy-to-cond` and `lispy-to-ifs` into a single, self-reversing
  function `lispy-cond<->if-dwim`
- Bugfix: handle empty `cond`s without maximum recursion depth errors
  (`lispy--to-ifs` has no base case for that)
- Bugfix: `lispy-cond<->-if-dwim`: don't error if the result is a single
  else-tail symbol (cond (t t)) -> `t` and `user-error`, because
  `lispy-different fails` (ignore `user-error`)
- Bugfix: don't silently swallow else-tail-tails: previously `(cond (t X
  XS...))` -> `X`, now `(progn X XS...)`
- Feature: `cond` now supports bracketed conditions: `(cond [t X XS...])`
  (Racket convention)
- Feature: `cond` now supports `:else` as an else tail (used in the `dash`
  library) and also a bare `else` in `scheme-mode`:
  ```scheme
  (cond (else X XS...)) ; -> (progn X XS...)
  ```

----

#