### PR TITLE
Improve lisp support

### DIFF
--- a/lispy-inline.el
+++ b/lispy-inline.el
@@ -174,7 +174,7 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
              (setq lispy-hint-pos (point))
              (lispy--show (lispy--clojure-args (lispy--current-function))))
 
-            ((eq major-mode 'lisp-mode)
+            ((derived-mode-p 'lisp-mode 'slime-repl-mode 'sly-mrepl-mode)
              (require 'le-lisp)
              (setq lispy-hint-pos (point))
              (lispy--show (lispy--lisp-args (lispy--current-function))))
@@ -279,7 +279,7 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
                (t
                 (or (lispy--describe-clojure-java sym)
                     (format "Could't resolve '%s" sym))))))))
-    ((eq major-mode 'lisp-mode)
+    ((derived-mode-p 'lisp-mode 'slime-repl-mode 'sly-mrepl-mode)
      (require 'le-lisp)
      (lispy--lisp-describe sym))
     ((eq major-mode 'python-mode)


### PR DESCRIPTION
- Include slime-repl-mode and sly-mrepl-mode into `lispy-describe-inline' and `lispy-arglist-inline' functions.
- Fix elisp reader choking on ?# char in Lisp syntax in `lispy-arglist-inline'.