### PR TITLE
`lispy--read`: don't run mode hooks

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7381,7 +7381,7 @@ See https://clojure.org/guides/weird_characters#_character_literal.")
          (mode major-mode)
          cbnd
          (str (with-temp-buffer
-                (funcall mode)
+                (delay-mode-hooks (funcall mode))
                 (insert str)
                 ;; ——— ly-raw —————————————————
                 (lispy--replace-regexp-in-code "(ly-raw" "(ly-raw raw")


### PR DESCRIPTION
Often mode-hooks will contain code to set-up REPLs, language servers and complex
editor support in general. However, `lispy--read` only cares about the syntax
table, so don't run them.


----

#