### PR TITLE
`lispy-mode`: le-clojure: modify capf locally

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -491,9 +491,9 @@ backward through lists, which is useful to move into special.
                (setq-local outline-regexp "\\(?:%\\*+\\|\\\\\\(?:sub\\)?section{\\)"))
               ((eq major-mode 'clojure-mode)
                (eval-after-load 'le-clojure
-                 '(setq completion-at-point-functions
-                   '(lispy-clojure-complete-at-point
-                     cider-complete-at-point)))
+                 '(setq-local completion-at-point-functions
+                              '(lispy-clojure-complete-at-point
+                                cider-complete-at-point)))
                (setq-local outline-regexp (substring lispy-outline 1)))
               ((eq major-mode 'python-mode)
                (setq-local lispy-outline "^#\\*+")


### PR DESCRIPTION
`lispy-mode` `setq`ed `completion-at-point-functions` globally, causing errors
in other buffers if that variable is not permanently buffer-local.

Only set `completion-at-point-functions` buffer-locally in `lispy-mode`.


----

#