### PR TITLE
Correct evilcp theme's wrong command at "M-down".

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -9688,7 +9688,7 @@ When ARG is non-nil, unquote the current string."
     (define-key map (kbd "DEL") 'lispy-backward-delete)
     (define-key map (kbd "M-s") 'lispy-splice)
     (define-key map (kbd "M-<up>") 'lispy-splice-sexp-killing-backward)
-    (define-key map (kbd "M-<down>") 'lispy-splice-sexp-killing-backward)
+    (define-key map (kbd "M-<down>") 'lispy-splice-sexp-killing-forward)
     (define-key map (kbd "M-r") 'lispy-raise-sexp)
     (define-key map (kbd "M-?") 'lispy-convolute-sexp)
     (define-key map (kbd "M-S") 'lispy-split)


### PR DESCRIPTION
In `lispy-mode-map-evilcp`
```
    (define-key map (kbd "M-<up>") 'lispy-splice-sexp-killing-backward)
    (define-key map (kbd "M-<down>") 'lispy-splice-sexp-killing-backward) ; should be forward
```
The corresponding splicing command should kill forward like paredit theme instead of backward ("M-up" does that already).