### PR TITLE
Fix lispy--delimiter-space-unless when spaces are not in the syntax t…

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7992,7 +7992,7 @@ PRECEDING-SYNTAX-ALIST should be an alist of `major-mode' to a list of regexps.
 When `looking-back' at any of these regexps, whitespace, or a delimiter, do not
 insert a space."
   (lispy--space-unless
-   (concat "^\\|\\s-\\|" lispy-left
+   (concat "^\\|[[:space:]]\\|" lispy-left
            (lispy--preceding-syntax preceding-syntax-alist "\\|"))))
 
 (defun lispy--reindent (&optional arg)


### PR DESCRIPTION
…able

This is the case with SLY.  Previously, typeing "(" at the prompt would insert a
spurious space.
Using [[:space:]] is safer because it matches spaces regardless of the syntax table.

Fixes https://github.com/abo-abo/lispy/issues/550.