### PR TITLE
Fix space key in edebug-eval-expression with lispy-mode on.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1902,7 +1902,8 @@ If jammed between parens, \"(|(\" unjam: \"(| (\". If after an opening delimiter
 and before a space (after wrapping a sexp, for example), do the opposite and
 delete the extra space, \"(| foo)\" to \"(|foo)\"."
   (interactive "p")
-  (cond ((bound-and-true-p edebug-active)
+  (cond ((and (bound-and-true-p edebug-active)
+              (lispy--edebug-commandp))
          (edebug-step-mode))
         ((region-active-p)
          (goto-char (region-end))


### PR DESCRIPTION
When typing in `edebug-eval-expression` with `lispy-mode`
on (`lispy-mode` was enabled for eval-expression), "SPC" key is always
forwarded to `edebug-step-mode`, making it hard to type " " without
`quote-insert` ("C-q").

Fix by checking `lispy--edebug-commandp` after knowing `edebug-active` is `t`.