### PR TITLE
lispy.el (lispy-raise-minor-mode): Fix duplication in alist

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -515,7 +515,7 @@ backward through lists, which is useful to move into special.
   (let ((x (assq mode minor-mode-map-alist)))
     (when x
       (setq minor-mode-map-alist
-            (cons x (delq mode minor-mode-map-alist))))))
+            (cons x (delq x minor-mode-map-alist))))))
 
 ;;* Macros
 (defmacro lispy-dotimes (n &rest bodyform)


### PR DESCRIPTION
`delq` deletes elements `eq` to the given value, so we should pass `x`, which is a cons, rather than `mode`, which is a symbol.