### PR TITLE
Also detect minibuffer-mode

### DIFF
--- a/lispy-inline.el
+++ b/lispy-inline.el
@@ -109,7 +109,9 @@ The caller of `lispy--show' might use a substitute e.g. `describe-function'."
   :group 'lispy)
 
 (defvar lispy-elisp-modes
-  '(emacs-lisp-mode lisp-interaction-mode eltex-mode minibuffer-inactive-mode
+  '(emacs-lisp-mode lisp-interaction-mode eltex-mode
+                    minibuffer-mode
+                    minibuffer-inactive-mode
                     suggest-mode)
   "Modes for which `lispy--eval-elisp' and related functions are appropriate.")
 

--- a/lispy.el
+++ b/lispy.el
@@ -7925,7 +7925,8 @@ Defaults to `error'."
       (forward-line 1))
     (move-marker end nil)))
 
-(defvar lispy-no-indent-modes '(minibuffer-inactive-mode
+(defvar lispy-no-indent-modes '(minibuffer-mode
+                                minibuffer-inactive-mode
                                 comint-mode)
   "List of major modes where `indent-for-tab-command' should not be used.
 `lispy--indent-for-tab' will do nothing if the current mode or any of its parent


### PR DESCRIPTION
Recently, on Emacs master branch, a commit 55db25b257 was pushed to fix
Emacs bug [47150](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=47150). This bug was related to an incorrect implementation of
minibuffer-inactive-mode. It used to be the case that after the first
usage of the minibuffer, it stucks in minibuffer-inactive-mode, though
minibuffer-inactive-mode was intended for a completely different
purpose, and the minibuffer on the current frame should NOT be inactive.
The new design is to have two possible major modes for the minibuffer:
minibuffer-mode when it is active, and minibuffer-inactive-mode when it
is inactive.