### PR TITLE
Use custom `inserter` if applicable

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -8725,7 +8725,10 @@ PLIST currently accepts:
 
              ((lispy--in-string-or-comment-p)
               (setq this-command 'self-insert-command)
-              (call-interactively 'self-insert-command))
+              (call-interactively
+               (quote
+                ,(or inserter
+                     'self-insert-command))))
 
              ((or (lispy-left-p)
                   (lispy-right-p)


### PR DESCRIPTION
Previously the inserter was only called in the default case, which is not reached if the point is in a string or comment. The `inserter` can be string- or comment-sensitive as needed, and this change allows it to be called in all insert cases.