### PR TITLE
Make the dependency on counsel-imenu optional

### DIFF
--- a/lispy-pkg.el
+++ b/lispy-pkg.el
@@ -3,6 +3,5 @@
   '((emacs "24.3")
     (ace-window "0.9.0")
     (iedit "0.9.9")
-    (counsel "0.11.0")
     (hydra "0.14.0")
     (zoutline "0.1.0")))

--- a/lispy.el
+++ b/lispy.el
@@ -278,6 +278,12 @@ The hint will consist of the possible nouns that apply to the verb."
   "Keys for jumping."
   :type '(repeat :tag "Keys" (character :tag "char")))
 
+(declare-function counsel-imenu "ext:counsel")
+
+(defcustom lispy-imenu-function #'counsel-imenu
+  "Function used to jump to an imenu entry."
+  :type 'function)
+
 (defface lispy-command-name-face
   '((((class color) (background light))
      :background "#d8d8f7" :inherit font-lock-function-name-face)
@@ -4193,8 +4199,6 @@ When ARG isn't nil, call `lispy-goto-projectile' instead."
        (mapcar #'lispy--format-tag-line candidates))
      #'lispy--action-jump)))
 
-(declare-function counsel-imenu "ext:counsel")
-
 (defun lispy-goto-local (&optional arg)
   "Jump to symbol within current file.
 When ARG is non-nil, force a reparse."
@@ -4207,7 +4211,7 @@ When ARG is non-nil, force a reparse."
                  (lispy--fetch-tags (list (buffer-file-name))))
          #'lispy--action-jump))
     (no-semantic-support
-     (counsel-imenu))))
+     (funcall lispy-imenu-function))))
 
 (defun lispy-goto-elisp-commands (&optional arg)
   "Jump to Elisp commands within current file.

--- a/targets/install-deps.el
+++ b/targets/install-deps.el
@@ -8,7 +8,6 @@
     sly
     geiser
     clojure-mode
-    counsel
     hydra
     ace-window
     helm


### PR DESCRIPTION
This aims to resolve #610. It allows the user to replace `counsel-imenu` with something else by customizing `lispy-imenu-function` variable.

Note that the user will have to install `counsel` separately to use the default setting. I am not sure if this is right. Please feel free to amend this PR.