### PR TITLE
README.md: Suggest a way to fix the indentation of eval-expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ in the minibuffer during `eval-expression`:
 ```cl
 (defun conditionally-enable-lispy ()
   (when (eq this-command 'eval-expression)
+    ;; Set the correct `indent-line-function' to fix the indentation.
+    (setq-local indent-line-function #'lisp-indent-line)
     (lispy-mode 1)))
 (add-hook 'minibuffer-setup-hook 'conditionally-enable-lispy)
 ```


### PR DESCRIPTION
`eval-expression` is pretty useful for inspecting the buffer-local things, but when enabled `lispy-mode` in `eval-expression`,
lispy keeps doing wired indentation because of the wrong `indent-line-function`. This pull request suggests a way in README to fix the indentation of `eval-expression`.