### PR TITLE
lispy.el (lispy-backtick): Use self-insert-command

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -2025,13 +2025,13 @@ For Clojure modes, toggle #_ sexp comment."
           (lispy-different)))
     (self-insert-command arg)))
 
-(defun lispy-backtick ()
-  "Insert `."
-  (interactive)
+(defun lispy-backtick (&optional arg)
+  "Insert ` ARG times."
+  (interactive "p")
   (if (region-active-p)
       (lispy--surround-region "`" "'")
     (lispy--space-unless "\\s-\\|\\s(\\|[:?`']\\|\\\\")
-    (insert "`")))
+    (self-insert-command arg)))
 
 (defun lispy-tilde (arg)
   "Insert ~ ARG times.


### PR DESCRIPTION
Unlike `insert`, `self-insert-command` allows `electric-pair` and `smartparens` to auto-close the pair ("`" and "'").