### PR TITLE
Fix lispy-backward-kill-word delimiter-balancing

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -1223,8 +1223,9 @@ If position isn't special, move to previous or error."
     (lispy-dotimes arg
       (when (lispy--in-comment-p)
         (skip-chars-backward " \n"))
-      (if (memq (char-syntax (char-before))
-                '(?w ?_ ?\s))
+      (if (and (memq (char-syntax (char-before))
+                     '(?w ?_ ?\s))
+               (lispy-looking-back "\\(?:\\sw\\|\\s_\\)\\s-+"))
           (if (lispy-looking-back "\\_<\\s_+")
               (delete-region (match-beginning 0)
                              (match-end 0))


### PR DESCRIPTION
* lispy.el (lispy-backward-kill-word): When looking back at ") ", we
would take the first if's then branch because the char before is
whitespace. However, this branch would call backward-kill-word which
doesn't skip over delimiters. Prevent this situation by taking the then
branch only if we're looking back at a word or symbol constituent
followed by whitespace, in which case backward-kill-word behaves
correctly. If we're not looking back at such a pattern, we end up in the
else branch, which does skip over delimiters.

Fixes #584