### PR TITLE
Fix parinfer theme's TAB in eval-expression

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -2463,7 +2463,11 @@ If indenting does not adjust indentation or move the point, call
         (bnd (when (region-active-p)
                (cons (region-beginning)
                      (region-end)))))
-    (indent-for-tab-command)
+    ;; the current TAB may not always be `indent-for-tab-command'
+    (cond
+     ((memq major-mode '(minibuffer-mode minibuffer-inactive-mode))
+      (completion-at-point))
+     (t (indent-for-tab-command)))
     (when (and (= tick (buffer-chars-modified-tick))
                (= pt (point)))
       (if bnd


### PR DESCRIPTION
lispy-indent-adjust-parens now tries completion-at-point instead of
indent-for-tab-command in minibuffers, as the latter doesn't perform
code completion in eval-expression.

Fixes #630