### PR TITLE
lispy--read: support clisp special character names

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -7389,7 +7389,9 @@ See https://clojure.org/guides/weird_characters#_character_literal.")
                   (lispy--read-replace " *,+" "clojure-commas"))
                 ;; ——— \ char syntax (LISP)————
                 (goto-char (point-min))
-                (while (re-search-forward "#\\\\\\(.\\)" nil t)
+                (while (let ((case-fold-search nil))
+                         ;; http://lispworks.com/documentation/HyperSpec/Body/02_ac.htm
+                         (re-search-forward "#\\\\\\(space\\|newline\\|.\\)" nil t))
                   (unless (lispy--in-string-or-comment-p)
                     (replace-match (format "(ly-raw lisp-char %S)"
                                            (substring-no-properties


### PR DESCRIPTION
Closes abo-abo/lispy#641.

The function `lispy--insert` doesn't need to change because we just insert whatever the content in the third cell in `(ly-raw ...)`.