### PR TITLE
Modify completion-at-point-functions locally and don't override.

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -504,9 +504,7 @@ backward through lists, which is useful to move into special.
                (setq-local outline-regexp "\\(?:%\\*+\\|\\\\\\(?:sub\\)?section{\\)"))
               ((eq major-mode 'clojure-mode)
                (eval-after-load 'le-clojure
-                 '(setq completion-at-point-functions
-                        '(lispy-clojure-complete-at-point
-                          cider-complete-at-point)))
+                 '(add-hook 'completion-at-point-functions #'lispy-clojure-complete-at-point nil t))
                (setq-local outline-regexp (substring lispy-outline 1)))
               ((eq major-mode 'python-mode)
                (setq-local lispy-outline "^#\\*+")


### PR DESCRIPTION
This simple modification only changes `completion-at-point-functions` locally, and it adds `#'lispy-clojure-complete-at-point` to it, instead of overiding the var.

Since it's only evaluated after `cider-mode`, we can count that `cider-complete-at-point` is already in the capf.

And adding the lispy function in that way, it makes it play better with other packages that locally binds  `completion-at-point-functions`, like eglot.

The same idea is used by [CIDER](https://github.com/clojure-emacs/cider/blob/bc8903b0c85cf0891f106337eabfc6f747d262a1/cider-mode.el#L1057C1-L1057C1)