### PR TITLE
fix: new interface for cider--display-interactive-eval-result

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -4253,8 +4253,11 @@ When at an outline, eval the outline."
                       (lispy-message res))
                      ((or (fboundp 'cider--display-interactive-eval-result)
                           (require 'cider nil t))
-                      (cider--display-interactive-eval-result
-                       res (cdr (lispy--bounds-dwim))))
+                      (if (version< cider-version "1.9.0")
+                        (cider--display-interactive-eval-result
+                          res (cdr (lispy--bounds-dwim)))
+                        (cider--display-interactive-eval-result
+                          res 'value (cdr (lispy--bounds-dwim)))))
                      ((or (fboundp 'eros--eval-overlay)
                           (require 'eros nil t))
                       (eros--eval-overlay


### PR DESCRIPTION
Function changed at https://github.com/clojure-emacs/cider/pull/3524/files#diff-8baace59939423f7b471afc53d48d62904fbac0d6ef7b5a1960f814cca9d3627R295
which included in cider version v1.9.0 https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md?plain=1#L18C1-L18C202

currently `(cl-assert (symbolp value-type))` fails 