### PR TITLE
Small improvements to `lispy-eval`

### DIFF
--- a/lispy.el
+++ b/lispy.el
@@ -4244,20 +4244,22 @@ When at an outline, eval the outline."
                   (looking-at lispy-outline-header))
              (lispy-eval-outline))
             (t
-             (let ((res (lispy--eval e-str)))
+             (let ((res (lispy--eval e-str))
+                   (has-cider (or (fboundp 'cider--display-interactive-eval-result)
+                                  (require 'cider nil t))))
                (when (memq major-mode lispy-clojure-modes)
                  (setq res (lispy--clojure-pretty-string res)))
                (when lispy-eval-output
                  (setq res (concat lispy-eval-output res)))
                (cond ((eq lispy-eval-display-style 'message)
                       (lispy-message res))
-                     ((or (fboundp 'cider--display-interactive-eval-result)
-                          (require 'cider nil t))
-                      (cider--display-interactive-eval-result
-                       res (cdr (lispy--bounds-dwim))))
-                     ((or (fboundp 'eros--eval-overlay)
-                          (require 'eros nil t))
+                     ((and (or (fboundp 'eros--eval-overlay)
+                               (require 'eros nil t))
+                           (if has-cider (not (memq major-mode lispy-clojure-modes)) t))
                       (eros--eval-overlay
+                       res (cdr (lispy--bounds-dwim))))
+                     (has-cider
+                      (cider--display-interactive-eval-result
                        res (cdr (lispy--bounds-dwim))))
                      (t
                       (error "Please install CIDER >= 0.10 or eros to display overlay"))))))

--- a/lispy.el
+++ b/lispy.el
@@ -4257,7 +4257,7 @@ When at an outline, eval the outline."
                                (require 'eros nil t))
                            (if has-cider (not (memq major-mode lispy-clojure-modes)) t))
                       (eros--eval-overlay
-                       res (cdr (lispy--bounds-dwim))))
+                       (read res) (cdr (lispy--bounds-dwim))))
                      (has-cider
                       (cider--display-interactive-eval-result
                        res (cdr (lispy--bounds-dwim))))


### PR DESCRIPTION
First of all, thanks for the great package!

I've been using `lispy` for a long time, but when I recently switch over to doom emacs, I noticed `lispy-eval` wasn't working as I expected in the `overlay` mode. It was defaulting to using `cider` when it should've been using `eros` (for Common Lisp and emacs lisp). Also, the formatting included extra quotes. This PR fixes these issues.

I haven't checked the changes with clojure yet, but I suspect there's something broken there as well (cider is now insisting on a symbol argument for `cider--display-interactive-eval-result`).