### PR TITLE
lispy-pkg.el: add missing dependency indium

### DIFF
--- a/lispy-pkg.el
+++ b/lispy-pkg.el
@@ -3,6 +3,7 @@
   '((emacs "24.3")
     (ace-window "0.9.0")
     (iedit "0.9.9")
+    (indium "2.1.4")
     (swiper "0.13.4")
     (hydra "0.14.0")
     (zoutline "0.2.0")))


### PR DESCRIPTION
indium is introduced in 6f46e116c57d7be772c1b7bc81785c01352acc0d.

ref: https://github.com/NixOS/nixpkgs/issues/335442